### PR TITLE
Harmonize the APCEMM build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,12 @@ cmake --build .
 will generate the executable in the `rundirs/SampleRunDir/` directory. 
 
 ## Getting Started
-To start a run from the aforementioned `rundirs/SampleRunDir`, simply call:
+To start a run from the aforementioned `rundirs/SampleRunDir`, simply call the following if the `APCEMM` executable was built in the `Code.v05-00` directory:
 ```
-./../../Code.v05-00 input.yaml
+./../../Code.v05-00/APCEMM input.yaml
 ```
+You can replace the `Code.v05-00` directory from the above command with the location where your `APCEMM` executable is.
+
 Three examples and their accompanying jupyter notebooks for postprocessing tutorials are provided in the `examples` folder. The first example is one where the contrail doesn't persists, and only focuses on analyzing the output of the early plume model (EPM) module of APCEMM. The second example is a persistent contrail simulation where the ice supersaturated layer depth is specified. The third example features using a meteorological input file.
 
 The input file options are explained via comments in the file `rundirs/SampleRunDir/input.yaml`

--- a/examples/Example1_EPM/run_example1.sh
+++ b/examples/Example1_EPM/run_example1.sh
@@ -1,5 +1,7 @@
-cd ../../Code.v05-00/
-cmake . && cmake --build . || exit 1
+cd ../../
+mkdir build
+cd build
+cmake ../Code.v05-00 && cmake --build . || exit 1
 cd ../examples/Example1_EPM
 export APCEMM_runDir="."
-./../../Code.v05-00/APCEMM input.yaml
+./../../build/APCEMM input.yaml

--- a/examples/Example2_Impose_Depth/run_example2.sh
+++ b/examples/Example2_Impose_Depth/run_example2.sh
@@ -1,5 +1,7 @@
-cd ../../Code.v05-00/
-cmake . && cmake --build . || exit 1
+cd ../../
+mkdir build
+cd build
+cmake ../Code.v05-00 && cmake --build . || exit 1
 cd ../examples/Example2_Impose_Depth
 export APCEMM_runDir="."
-./../../Code.v05-00/APCEMM input.yaml
+./../../build/APCEMM input.yaml

--- a/examples/Example3_met_input/run_example3.sh
+++ b/examples/Example3_met_input/run_example3.sh
@@ -1,5 +1,7 @@
-cd ../../Code.v05-00/
-cmake . && cmake --build . || exit 1
+cd ../../
+mkdir build
+cd build
+cmake ../Code.v05-00 && cmake --build . || exit 1
 cd ../examples/Example3_met_input
 export APCEMM_runDir="."
-./../../Code.v05-00/APCEMM input.yaml
+./../../build/APCEMM input.yaml


### PR DESCRIPTION
This PR addresses the fact that the example scripts were contradictory with the README regarding where APCEMM should be built.

This is done in two commits:

1. The first commit changes the example scripts to build APCEMM in a `build` folder. It also runs APCEMM from the same folder.
2. The second commit fixes what I believe to be a mistake in the README, as well as adding some clarification.