### PR TITLE
Added debug options for reproducibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,4 @@ CMakeCache.txt
 cmake_install.cmake
 
 /Code.v05-00/vcpkg_installed/
+/Code.v05-00/include/APCEMM.h

--- a/Code.v05-00/CMakeLists.txt
+++ b/Code.v05-00/CMakeLists.txt
@@ -6,12 +6,12 @@ set(CMAKE_TOOLCHAIN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/submodules/vcpkg/scripts/b
 project(APCEMM)
 
 # Options
-SET(DEBUG 0)
+option(DEBUG "Enable debug mode" OFF)
 SET(RINGS 0)
 SET(OMP 1)
 option(BUILD_TEST ON)
 
-if (NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "")	
+if (NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "")
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING "" FORCE)
     include(CheckCXXCompilerFlag)
     CHECK_CXX_COMPILER_FLAG("-march=native" COMPILER_SUPPORTS_MARCH_NATIVE)
@@ -88,3 +88,6 @@ enable_testing()
 add_subdirectory(tests)
 #endif()
 
+if (DEBUG)
+  message(STATUS "DEBUG mode is enabled")
+endif()

--- a/Code.v05-00/include/APCEMM.h
+++ b/Code.v05-00/include/APCEMM.h
@@ -1,3 +1,0 @@
-/* #undef DEBUG */
-/* #undef RINGS */
-#define OMP

--- a/Code.v05-00/include/APCEMM.h.in
+++ b/Code.v05-00/include/APCEMM.h.in
@@ -1,3 +1,5 @@
+/* Template for CMake to generate an APCEMM.h with appropriate preprocessor definitions
+given boolean values of the parameters during CMake compilation. */
 #cmakedefine DEBUG
 #cmakedefine RINGS
 #cmakedefine OMP

--- a/Code.v05-00/src/Core/Main.cpp
+++ b/Code.v05-00/src/Core/Main.cpp
@@ -54,6 +54,13 @@ int main( int argc, char* argv[])
     
     const unsigned int model = 1;
 
+    #ifdef DEBUG
+        std::cout << "-------- DEBUG is enabled --------" << std::endl;
+    #endif
+
+    // Set the seed once at the top-level
+    setSeed();
+
     /* Declaring the Input Option object for use in APCEMM */
     OptInput Input_Opt; // Input Option object
 

--- a/Code.v05-00/src/Util/MC_Rand.cpp
+++ b/Code.v05-00/src/Util/MC_Rand.cpp
@@ -10,14 +10,20 @@
 /* File                 : MC_Rand.cpp                               */
 /*                                                                  */
 /* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
-
+#include "APCEMM.h"
 #include "Util/MC_Rand.hpp"
 
 void setSeed() {
 
-    /* Sets seed for pseudo-random generator.
-     * For that use the current unix timestamp as our random seed. */
-    srand(time(0));
+    // Sets seed for pseudo-random generator.
+    #ifdef DEBUG
+        // With DEBUG compile flag set a constant seed for reproducibility
+        std::cout << "Compiled in DEBUG mode: random seed is set to 0 for all simulations" << std::endl;
+        srand(0);
+    #else
+        // Otherwise use the current unix timestamp as our random seed. 
+        srand(time(NULL));
+    #endif
 
 } /* End of setSeed */
 

--- a/Code.v05-00/src/YamlInputReader/YamlInputReader.cpp
+++ b/Code.v05-00/src/YamlInputReader/YamlInputReader.cpp
@@ -1,3 +1,4 @@
+#include "APCEMM.h"
 #include "YamlInputReader/YamlInputReader.hpp"
 
 using std::cout;
@@ -80,6 +81,12 @@ namespace YamlInputReader{
         if(input.SIMULATION_OMP_NUM_THREADS < 1){
             throw std::invalid_argument("OpenMP Num Threads (under SIMULATION MENU) cannot be less than 1!");
         }
+
+        #ifdef DEBUG
+            // In DEBUG, force single threaded code to avoid non-reproducibility due to multithreading
+            std::cout << "Compiled in DEBUG mode: setting OMP_NUM_THREADS = 1 to force single threading" << std::endl;
+            input.SIMULATION_OMP_NUM_THREADS = 1;
+        #endif
 
         YAML::Node paramSweepSubmenu = simNode["PARAM SWEEP SUBMENU"];
         input.SIMULATION_PARAMETER_SWEEP = parseBoolString(paramSweepSubmenu["Parameter sweep (T/F)"].as<string>(), "Parameter sweep (T/F");
@@ -354,7 +361,6 @@ namespace YamlInputReader{
             if(colon_split_tokens.size() != 0 && colon_split_tokens.size() != 2){
                 throw std::invalid_argument("Monte Carlo Simulation requires parameter input format of min:max or a singular (constant) value at " + paramLocation + "!");
             }
-            setSeed();
             Vector_1D paramVector;
             const double min = parseDoubleString(colon_split_tokens[0], "");
             const double max = parseDoubleString(colon_split_tokens[1], "");

--- a/README.md
+++ b/README.md
@@ -66,3 +66,52 @@ Three examples and their accompanying jupyter notebooks for postprocessing tutor
 The input file options are explained via comments in the file `rundirs/SampleRunDir/input.yaml`
 
 Advanced simulation parameters hidden in the input files (e.g. Aerosol bin size ratios, minimum/max bin aerosol sizes, etc) can be modified in `Code.v05-00/src/include/Parameters.hpp`. 
+
+## Debugging
+
+APCEMM can be compiled in debug mode to ensure reproducible results during testing. This fixes the seed of the random number generator and enforces single threaded computation. It can be enabled by passing the ```-DDEBUG=ON``` flag to CMake:
+
+```
+cmake ../Code.v05-00 -DDEBUG=ON
+```
+
+To debug APCEMM using gdb and the VSCode debugger the binary can be compiled with debug instructions by adding the ```-DCMAKE_BUILD_TYPE="Debug"``` flag. This comes at a significant cost in performance.
+
+ ```
+cmake ../Code.v05-00 -DCMAKE_BUILD_TYPE="Debug"
+ ```
+ 
+ Here's an example configuration of the VSCode debugger in ```APCEMM/.vscode/launch.json```:
+
+```
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "(gdb) Launch APCEMM debug",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/rundirs/debug/APCEMM",
+            "cwd": "${workspaceFolder}/rundirs/debug/test_rundir/",
+            "args": ["${workspaceFolder}/examples/Example1_EPM/input.yaml"],
+            "environment": [
+                {
+                    "name": "LD_LIBRARY_PATH",
+                    "value": "${workspaceFolder}/build/lib"
+                },
+            ],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                }
+            ]
+        },
+    ]
+}
+```
+
+This configuration runs the APCEMM binary located in ```"${workspaceFolder}/rundirs/debug/``` using the input file located in ```${workspaceFolder}/examples/Example1_EPM/input.yaml``` and the working directory ``` ${workspaceFolder}/rundirs/debug/test_rundir/```. Paths can be changed to suit the case to debug.


### PR DESCRIPTION
To make regression testing possible we need APCEMM to generate deterministic results. There are two sources of "non-deterministicness" in APCEMM right now: the random temperature perturbations and multi-threading.

This PR adds a compilation option to:
- Set a constant seed for the random number generator hardcoded in the binary
- Enforce single threading regardless of user input

This is documented in the README for compiling in this mode as well as for compiling the binary with debug instructions.

Also untracks APCEMM.h which is regenerated every compilation by CMake using the APCEMM.h.in template as it changes depending on if the -DDEBUG flag is on.