### PR TITLE
Fix void formation in H2O field

### DIFF
--- a/Code.v05-00/include/Core/LAGRIDPlumeModel.hpp
+++ b/Code.v05-00/include/Core/LAGRIDPlumeModel.hpp
@@ -77,7 +77,7 @@ class LAGRIDPlumeModel {
         void runTransport(double timestep);
         void remapAllVars(double remapTimestep);
         void trimH2OBoundary();
-        LAGRID::twoDGridVariable remapVariable(const VectorUtils::MaskInfo& maskInfo, const BufferInfo& buffers, const Vector_2D& phi, const std::vector<std::vector<int>>& mask);
+        std::pair<LAGRID::twoDGridVariable,LAGRID::twoDGridVariable> remapVariable(const VectorUtils::MaskInfo& maskInfo, const BufferInfo& buffers, const Vector_2D& phi, const std::vector<std::vector<int>>& mask);
         double totalAirMass();
         void runCocipH2OMixing(const Vector_2D& h2o_old, const Vector_2D& h2o_amb_new, MaskType& mask_old, MaskType& mask_new);
 

--- a/Code.v05-00/include/LAGRID/RemappingFunctions.hpp
+++ b/Code.v05-00/include/LAGRID/RemappingFunctions.hpp
@@ -53,7 +53,7 @@ namespace LAGRID {
         Vector_1D yCoords;
         double dx;
         double dy;
-        void addBuffer(double bufLen_left, double bufLen_right, double bufLen_top, double bufLen_bot);
+        void addBuffer(double bufLen_left, double bufLen_right, double bufLen_top, double bufLen_bot, double fillValue);
     };
 
     inline double coveredArea(const Remapping& remapping, const MassBox& b, int i, int j) {
@@ -77,6 +77,7 @@ namespace LAGRID {
     double diffusionLossFunctionExact(const FreeCoordBoxGrid& boxGrid, const Remapping& remapping);
     double diffusionLossFunctionBoundaryEstimate(const FreeCoordBoxGrid& boxGrid, const Remapping& remapping);
     twoDGridVariable mapToStructuredGrid(const FreeCoordBoxGrid& boxGrid, const Remapping& remapping);
+    twoDGridVariable getUnusedFraction(const FreeCoordBoxGrid& boxGrid, const Remapping& remapping);
 
     Vector_2D initVarToGrid(double mass, const Vector_1D& xEdges, const Vector_1D& yEdges,
                             std::function<double(double, double)> weightFunction, double logBinRatio = 1 );

--- a/Code.v05-00/src/Core/LAGRIDPlumeModel.cpp
+++ b/Code.v05-00/src/Core/LAGRIDPlumeModel.cpp
@@ -495,8 +495,8 @@ void LAGRIDPlumeModel::remapAllVars(double remapTimestep) {
     auto met_H2O = met_.H2O_field();
     int ny = H2O_.size();
     int nx = H2O_[0].size();
-    for(int j=1; j < (ny-1); j++) {
-        for(int i=1; i < (nx-1); i++) {
+    for(int j=0; j < ny; j++) {
+        for(int i=0; i < nx; i++) {
             H2O_[j][i] += std::max(0.0,unusedFraction.phi[j][i]) * met_H2O[j][i];
         }
     }

--- a/Code.v05-00/tests/test_LAGRID.cpp
+++ b/Code.v05-00/tests/test_LAGRID.cpp
@@ -84,7 +84,7 @@ TEST_CASE("FreeCoordBoxGrid and Remapping") {
     }
 
     SECTION("Adding Buffer") {
-        twoDGrid.addBuffer(6, 10, 4, 8);
+        twoDGrid.addBuffer(6, 10, 4, 8, 0.0);
         REQUIRE(twoDGrid.yCoords.size() == 12);
         REQUIRE(twoDGrid.xCoords.size() == 19);
         REQUIRE(twoDGrid.xCoords[0] == -6);


### PR DESCRIPTION
As described in https://github.com/MIT-LAE/APCEMM/issues/21, voids can appear in the H2O field during step-to-step remapping. This behavior has been traced back to the routine remapVariable, which calculates the contribution of each grid cell in the previous timestep's grid to the concentration in the new grid. Only cells which have ice mass are considered, which means that zeros are implicitly assumed outside the contrail - resulting in boundary values being non-zero but (in the case of H2O, where the background quantity is non-zero) lower than the background. This is now fixed by tracking the fraction of each output grid cell which is not mapped to (`unusedFraction`), and then adding `met_.H2O_ * unusedFraction` to `H2O_` after regridding.