### PR TITLE
Fix all compiler warnings

### DIFF
--- a/Code.v05-00/CMakeLists.txt
+++ b/Code.v05-00/CMakeLists.txt
@@ -59,6 +59,10 @@ target_link_libraries(${PROJECT_NAME} PRIVATE Catch2::Catch2 Catch2::Catch2WithM
 find_package(Eigen3 CONFIG REQUIRED)
 target_link_libraries(${PROJECT_NAME} PRIVATE Eigen3::Eigen)
 
+find_package(fmt CONFIG REQUIRED)
+# target_link_libraries(${PROJECT_NAME} PRIVATE fmt::fmt)
+target_link_libraries(${PROJECT_NAME} PRIVATE fmt::fmt-header-only)
+
 find_package(FFTW3 CONFIG REQUIRED)
 target_link_libraries(${PROJECT_NAME} PRIVATE FFTW3::fftw3)
 

--- a/Code.v05-00/CMakeLists.txt
+++ b/Code.v05-00/CMakeLists.txt
@@ -26,6 +26,10 @@ elseif (NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
     endif()
     
+    # Turn on warnings always
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -fopenmp")
+
+
     #Enabling unsafe optimizations doesn't seem to affect the runtime much, but could be something to check just in case later.
     #-Michael
     #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffast-math -fno-trapping-math -funsafe-math-optimizations")
@@ -71,12 +75,13 @@ target_link_libraries(${PROJECT_NAME} PRIVATE OpenMP::OpenMP_CXX)
 
 
 # This ensures the header files of the necessary libraries are included
-include_directories(${Boost_INCLUDES})
-include_directories(${OpenMP_INCLUDES})
-include_directories(${FFTW_INCLUDES})
-include_directories(${NETCDF_INCLUDES})
-include_directories(${netCDFCxx_INCLUDE_DIRS})
-include_directories(${YAML_CPP_INCLUDE_DIR})
+# SYSTEM flag silences the compiler warnings from external dependencies 
+include_directories(SYSTEM ${Boost_INCLUDES})
+include_directories(SYSTEM ${OpenMP_INCLUDES})
+include_directories(SYSTEM ${FFTW_INCLUDES})
+include_directories(SYSTEM ${NETCDF_INCLUDES})
+include_directories(SYSTEM ${netCDFCxx_INCLUDE_DIRS})
+include_directories(SYSTEM ${YAML_CPP_INCLUDE_DIR})
 
 # Ensure header files of APCEMM are included
 include_directories(${CMAKE_SOURCE_DIR}/include)

--- a/Code.v05-00/include/Core/Diag_Mod.hpp
+++ b/Code.v05-00/include/Core/Diag_Mod.hpp
@@ -72,10 +72,12 @@ namespace Diag {
     * NY x NX x NFAM 
     * into netCDF files at a frequency specified by the input file */
 
-    //bool Diag_PL( const char* ROOTNAME,                     \
-    //              const int hh, const int mm, const int ss, \
-    //              const Solution& Data,                     \
-    //              const Mesh& m );
+    /*
+    bool Diag_PL( const char* ROOTNAME,                     \
+                 const int hh, const int mm, const int ss, \
+                 const Solution& Data,                     \
+                 const Mesh& m );
+    */
 
     #endif /* DIAG_MOD_H_INCLUDED */
 

--- a/Code.v05-00/include/Core/Input.hpp
+++ b/Code.v05-00/include/Core/Input.hpp
@@ -27,19 +27,16 @@ class Input
     double simulationTime_;
 
     double temperature_K_;
-    double pressure_Pa_;
     double relHumidity_w_;
     double horizDiff_;
     double vertiDiff_;
     double shear_;
-    double nBV_;
 
     double longitude_deg_;
     double latitude_deg_;
+    double pressure_Pa_;
 
     UInt emissionDOY_;
-    UInt emissionDay_;
-    UInt emissionMonth_;
     double emissionTime_;
 
     double EI_NOx_;
@@ -51,13 +48,7 @@ class Input
     double sootRad_;
 
     double fuelFlow_;
-
     double aircraftMass_;
-    double flightSpeed_;
-    double numEngines_;
-    double wingspan_;
-    double coreExitTemp_;
-    double bypassArea_;
 
     double backgNOx_;
     double backgHNO3_;
@@ -65,12 +56,23 @@ class Input
     double backgCO_;
     double backgCH4_;
     double backgSO2_;
+    
+    double flightSpeed_;
+    double numEngines_;
+    double wingspan_;
+    double coreExitTemp_;
+    double bypassArea_;
 
     std::string fileName_;
     std::string fileName_ADJ_;
     std::string fileName_BOX_;
     std::string fileName_micro_;
     std::string author_;
+
+    double nBV_;
+
+    UInt emissionDay_;
+    UInt emissionMonth_;
 
     private:
         void checkInputValidity();

--- a/Code.v05-00/include/Core/Mesh.hpp
+++ b/Code.v05-00/include/Core/Mesh.hpp
@@ -60,8 +60,9 @@ class Mesh
         void initCoordVectors(MeshDomainLimitsSpec limitsSpec);
 
         inline void calcAreas() {
-            for ( int j = 0; j < ny; j++ ) {
-                for ( int i = 0; i < nx; i++ ) {
+            // UInt to be consistent with mesh size definition
+            for ( UInt j = 0; j < ny; j++ ) {
+                for ( UInt i = 0; i < nx; i++ ) {
                     areas_[j][i] = dx_[i] * dy_[j];
                 }
             }

--- a/Code.v05-00/include/Core/Meteorology.hpp
+++ b/Code.v05-00/include/Core/Meteorology.hpp
@@ -86,7 +86,7 @@ class Meteorology
         inline double rhwAtAlt(double alt) const {
             Vector_1D rhwVec(yCoords_.size());
             Vector_1D h2o1D = H2O_1D();
-            for(int j = 0; j < yCoords_.size(); j++) {
+            for(std::size_t j = 0; j < yCoords_.size(); j++) {
                 rhwVec[j] = physFunc::H2OToRHw(h2o1D[j], tempBase_[j]);
             }
             return met::linInterpMetData(altitude_, rhwVec, alt);
@@ -105,7 +105,7 @@ class Meteorology
         inline const Vector_1D& tempBase() const { return tempBase_; }
         inline const Vector_1D H2O_1D() const {
             Vector_1D h2o1D(yCoords_.size());
-            for(int j = 0; j < yCoords_.size(); j++) {
+            for(std::size_t j = 0; j < yCoords_.size(); j++) {
                 h2o1D[j] = H2O_[j][0];
             }
             return h2o1D;

--- a/Code.v05-00/include/Core/Parameters.hpp
+++ b/Code.v05-00/include/Core/Parameters.hpp
@@ -40,7 +40,7 @@
 #define DPROF             1           /* Time profile of the initial diffusion parameter [0,1,2]
                                        * 0: Step
                                        * 1: Linear
-                                       * 2: Exponential
+                                       * 2: Exponential */
 
 /* Advection  */
 #define VX                0.0E+00     /* Steady-state horizontal advection velocity [m/s] */
@@ -50,7 +50,7 @@
 //#define V_SYN             5.0E-02     /* Velocity magnitude [m/s] */
 #define SYNPROF           1           /* Time profile of the initial synoptic lifting [0,1]
                                        * 0: Step
-                                       * 1: Exponential
+                                       * 1: Exponential */
 
 /* Chemistry parameters */
 #define KPP_RTOLS             1.00E-03    /* Relative tolerances in KPP */

--- a/Code.v05-00/include/Core/Structure.hpp
+++ b/Code.v05-00/include/Core/Structure.hpp
@@ -80,7 +80,7 @@ class Solution
                       const UInt j = 0, \
 		      const bool CHEMISTRY = 0 );
 
-        int SpinUp( Vector_1D &amb_Value,       \
+        void SpinUp( Vector_1D &amb_Value,       \
                     const Input &input,         \
                     const double airDens,   \
                     const double startTime, \

--- a/Code.v05-00/include/FVM_ANDS/AdvDiffSystem.hpp
+++ b/Code.v05-00/include/FVM_ANDS/AdvDiffSystem.hpp
@@ -226,6 +226,9 @@ namespace FVM_ANDS{
                             break;
                         }
                     }
+                    case FaceDirection::ERROR:{
+                        throw std::runtime_error("Received invalid face direction");
+                    }
                 }
                 return std::max(0.0, std::min(r, 1.0));
             }
@@ -322,12 +325,12 @@ namespace FVM_ANDS{
                     
                     case FaceDirection::WEST:
                         return pointID - ny_;
+                    
+                    // For consistency with previous implementation
+                    default:
+                        return -1;
                 }
-                return -1;
             }
-
-
     };
-
 }
 #endif

--- a/Code.v05-00/include/FVM_ANDS/AdvDiffSystem.hpp
+++ b/Code.v05-00/include/FVM_ANDS/AdvDiffSystem.hpp
@@ -10,6 +10,10 @@
 #include <memory>
 
 namespace FVM_ANDS{
+
+    // Separate the SOR solver for testing without having to build an AdvDiffSystem object
+    void sor_solve(const Eigen::SparseMatrix<double, Eigen::RowMajor> &A, const Eigen::VectorXd &rhs, Eigen::VectorXd &phi, double omega = 1.0, double threshold = 1e-3, int n_iters = 3);
+
     struct AdvDiffParams {
         AdvDiffParams(double u, double v, double shear, double Dh, double Dv, double dt){
             this->u = u;
@@ -35,7 +39,9 @@ namespace FVM_ANDS{
             void applyBoundaryCondition();
             void updateBoundaryCondition(const BoundaryConditions& bc);
             Eigen::VectorXd forwardEulerAdvection(bool operatorSplit = false, bool parallelAdvection = false) const noexcept;
-            const Eigen::VectorXd& sor_solve(double omega = 1.0, double threshold = 1e-3, int n_iters = 3);
+            // Breakup the implementation of sor_solve to allow for easy testing by inputing an arbitrary linear system to solve:
+            // Implementation is moved outside of the class, and make class method to be used in code
+            void sor_solve(double omega = 1.0, double threshold = 1e-3, int n_iters = 3){ FVM_ANDS::sor_solve(totalCoefMatrix_, rhs_, phi_, omega, threshold, n_iters); };
             inline const Eigen::VectorXd& getRHS() const { return rhs_; }
             inline const Eigen::VectorXd& phi() const { return phi_; }
             inline const std::vector<std::unique_ptr<Point>>& points() const { return points_; }

--- a/Code.v05-00/include/FVM_ANDS/AdvDiffSystem.hpp
+++ b/Code.v05-00/include/FVM_ANDS/AdvDiffSystem.hpp
@@ -232,9 +232,11 @@ namespace FVM_ANDS{
                             break;
                         }
                     }
-                    case FaceDirection::ERROR:{
-                        throw std::runtime_error("Received invalid face direction");
-                    }
+                    /* Function is never called with FaceDirection::ERROR, see call stack
+                    Placeholder value instead of throwing exception because function
+                    is marked as noexcept... */
+                    default:
+                        return -1;
                 }
                 return std::max(0.0, std::min(r, 1.0));
             }

--- a/Code.v05-00/include/FVM_ANDS/FVM_Solver.hpp
+++ b/Code.v05-00/include/FVM_ANDS/FVM_Solver.hpp
@@ -78,8 +78,8 @@ namespace FVM_ANDS{
             }
             static double eigenSqVectorNorm_double(const Vector_2D& vec) {
                 double sum = 0;
-                for (int j = 0; j < vec.size(); j++) {
-                    for (int i = 0; i < vec[0].size(); i++) {
+                for (std::size_t j = 0; j < vec.size(); j++) {
+                    for (std::size_t i = 0; i < vec[0].size(); i++) {
                         if(isnan(vec[j][i])){
                             //std::cout << j << " " << i << std::endl;
                         }

--- a/Code.v05-00/include/KPP/KPP.hpp
+++ b/Code.v05-00/include/KPP/KPP.hpp
@@ -47,7 +47,7 @@ void Update_JRates ( double JRates[], const double CSZA );
 void ComputeFamilies( const double V[], const double F[], const double RCT[], \
                       double familyRates[] );
 
-static int KPP_FAIL    = -1;
+// static int KPP_FAIL    = -1;
 // static int KPPADJ_FAIL = -5;
     
 

--- a/Code.v05-00/include/KPP/KPP.hpp
+++ b/Code.v05-00/include/KPP/KPP.hpp
@@ -47,8 +47,8 @@ void Update_JRates ( double JRates[], const double CSZA );
 void ComputeFamilies( const double V[], const double F[], const double RCT[], \
                       double familyRates[] );
 
-static int KPP_FAIL    = -1;
-static int KPPADJ_FAIL = -5;
+// static int KPP_FAIL    = -1;
+// static int KPPADJ_FAIL = -5;
     
 
 #ifdef __cplusplus

--- a/Code.v05-00/include/KPP/KPP.hpp
+++ b/Code.v05-00/include/KPP/KPP.hpp
@@ -47,7 +47,7 @@ void Update_JRates ( double JRates[], const double CSZA );
 void ComputeFamilies( const double V[], const double F[], const double RCT[], \
                       double familyRates[] );
 
-// static int KPP_FAIL    = -1;
+static int KPP_FAIL    = -1;
 // static int KPPADJ_FAIL = -5;
     
 

--- a/Code.v05-00/include/Util/MetFunction.hpp
+++ b/Code.v05-00/include/Util/MetFunction.hpp
@@ -50,7 +50,7 @@ namespace met
     double ComputeLapseRate( const double TEMP, const double RHi, \
                                  const double DEPTH );
                                  
-    int nearestNeighbor( const Vector_1D& xq, double x);
+    std::size_t nearestNeighbor( const Vector_1D& xq, double x);
     double linearInterp( const Vector_1D& xq, const Vector_1D& yq, double x );
     double linearInterp( double x1, double y1, double x2, double y2, double xq, bool support_extrapolation = false);
 

--- a/Code.v05-00/include/Util/VectorUtils.hpp
+++ b/Code.v05-00/include/Util/VectorUtils.hpp
@@ -28,8 +28,8 @@ namespace VectorUtils {
     template<typename FillWithType>
     void fill2DVec(Vector_2D& toFill, const FillWithType& fillWith, std::function<bool (double)> fillCondFunction) {
         #pragma omp parallel for
-        for(int j = 0; j < toFill.size(); j++) {
-            for(int i = 0; i < toFill[0].size(); i++) {
+        for(std::size_t j = 0; j < toFill.size(); j++) {
+            for(std::size_t i = 0; i < toFill[0].size(); i++) {
                 double fillWithValue;
                 if constexpr(std::is_arithmetic_v<FillWithType>) {
                     fillWithValue = fillWith;

--- a/Code.v05-00/include/YamlInputReader/YamlInputReader.hpp
+++ b/Code.v05-00/include/YamlInputReader/YamlInputReader.hpp
@@ -46,13 +46,11 @@ namespace YamlInputReader{
     inline double strToDouble(const string str, bool sciNotation = true){
         string s = trim(str);
         bool foundDot = false;
-        bool hasSign = false;
         if (s.length() != 0 && (s[0] == '-' || s[0] == '+')){
             s = s.substr(1);
-            hasSign = true;
         }
         if (s.length() == 0) throw (std::invalid_argument("Input Reader tried to process number of length 0! Please double-check your input!"));
-        for (int i = 0; i < s.length(); i++){
+        for (std::size_t i = 0; i < s.length(); i++){
             char c = s[i];
             if(std::isdigit(c)) continue;
             //Don't allow something like 10e2. or 3e-2.5
@@ -86,7 +84,7 @@ namespace YamlInputReader{
         try{
             return strToDouble(paramString);
         }
-        catch (std::invalid_argument e){
+        catch (const std::invalid_argument &e){
             throw std::invalid_argument(string(e.what()) + " at parameter " + paramLocation);
         }
 

--- a/Code.v05-00/src/AIM/Aerosol.cpp
+++ b/Code.v05-00/src/AIM/Aerosol.cpp
@@ -728,13 +728,6 @@ Aerosol::Aerosol(const Vector_1D& bin_Centers_, const Vector_1D& bin_Edges_, dou
         #pragma omp parallel if( !PARALLEL_CASES ) default( shared )
         {
 
-            /* All declarations here are enforced as thread private */
-
-            double partVol  = 0.0E+00;
-            double icePart_ = 0.0E+00;
-            double iceVol_  = 0.0E+00;
-
-            int jBin = -1;
             std::vector<int> toBin( nBin, 0 );
             std::vector<int>::iterator iterBegin, iterCurr, iterEnd;
 
@@ -758,8 +751,7 @@ Aerosol::Aerosol(const Vector_1D& bin_Centers_, const Vector_1D& bin_Edges_, dou
             }
 
             #pragma omp for                                                               \
-            private ( iNx, jNy, iBin, jBin, locP, locT              ) \
-            private ( partVol, icePart_, iceVol_                                ) \
+            private ( iNx, jNy, iBin, locP, locT              ) \
             schedule( static, 1                                                )
             for ( jNy = 0; jNy < Ny_max; jNy++ ) {
                 /* Store local pressure.
@@ -888,10 +880,7 @@ Aerosol::Aerosol(const Vector_1D& bin_Centers_, const Vector_1D& bin_Edges_, dou
          * - double :: Effective Diffusion Coefficient in m^2/s */
 
          const double dCoef = physFunc::CorrDiffCoef_H2O( r, T, P ); /* [m^2/s] */
-         const double p_sat = physFunc::pSat_H2Os( T );
-         const double p_h2o = physConst::R * T * H2O /(physConst::Na*1e-6);
          const double latS  = physFunc::LHeatSubl_H2O( T ); /* [J/kg] */
-         const double nSat  = physFunc::pSat_H2Os( T ) / ( physConst::kB * T ); /* [#/m^3] */
         
         //Base D_{eff} expression in Jacobson (1995), equation 2
         //We can NOT directly use expressions for something like dm/dt, dr/dt, dv/dt, etc because of the (S' - 1) term in the 
@@ -910,7 +899,7 @@ Aerosol::Aerosol(const Vector_1D& bin_Centers_, const Vector_1D& bin_Edges_, dou
     {
         std::vector<int> toBin(nBin, 0);
         double partVol;
-        for (int iBin = 0; iBin < nBin; iBin++)
+        for (UInt iBin = 0; iBin < nBin; iBin++)
         {
 
             toBin[iBin] = -1;
@@ -941,7 +930,7 @@ Aerosol::Aerosol(const Vector_1D& bin_Centers_, const Vector_1D& bin_Edges_, dou
         std::vector<int>::const_iterator iterBegin, iterCurr, iterEnd;
         double icePart_, iceVol_;
         int jBin;
-        for (int iBin = 0; iBin < nBin; iBin++)
+        for (UInt iBin = 0; iBin < nBin; iBin++)
         {
 
             icePart_ = 0.0E+00;
@@ -1404,7 +1393,7 @@ Aerosol::Aerosol(const Vector_1D& bin_Centers_, const Vector_1D& bin_Edges_, dou
         double chiMax = *std::max_element(chiMax_x.begin(), chiMax_x.end());
         int i_left = -1;
         int i_right = -1;
-        for (int i = 0; i < Nx; i++) {
+        for (UInt i = 0; i < Nx; i++) {
             bool inContrail = chiMax_x[i] > thres*chiMax;
             if(inContrail) {
                 i_right = i;
@@ -1425,7 +1414,7 @@ Aerosol::Aerosol(const Vector_1D& bin_Centers_, const Vector_1D& bin_Edges_, dou
         double chiMax = *std::max_element(chiMax_y.begin(), chiMax_y.end());
         int j_bot = -1;
         int j_top = -1;
-        for (int j = 0; j < Ny; j++) {
+        for (UInt j = 0; j < Ny; j++) {
             bool inContrail = chiMax_y[j] > thres*chiMax;
             if(inContrail) {
                 j_top = j;
@@ -1730,8 +1719,6 @@ Aerosol::Aerosol(const Vector_1D& bin_Centers_, const Vector_1D& bin_Edges_, dou
         Vector_1D out(4, 0.0E+00);
 
         Vector_1D PDF(nBin, 0.0E+00);
-
-        double w = 0.0E+00;
 
         #pragma omp parallel for default(shared) private(iNx, jNy, iBin) \
             schedule(dynamic, 1) if (!PARALLEL_CASES)

--- a/Code.v05-00/src/Core/Aircraft.cpp
+++ b/Code.v05-00/src/Core/Aircraft.cpp
@@ -94,7 +94,7 @@ double Aircraft::VortexLosses( const double EI_Soot,    \
      * */
 
     /* Debug flag? */
-    const bool ACDEBUG = 0;
+    // const bool ACDEBUG = 0;
 
     /* Compute volume and mass of soot particles emitted */
     const double volParticle  = 4.0 / 3.0 * physConst::PI * pow( EI_SootRad, 3.0 ); //EI_SootRad in m -> volume in m3
@@ -241,10 +241,10 @@ void Aircraft::setFuelFlow(const double ff)
 void Aircraft::setVFlight(const double Vf, double temperature_K)
 {
 
-    if ( Vf > 0.0E+00 )
+    if ( Vf > 0.0E+00 ){
         vFlight_ms_ = Vf;
-        machNumber_ = vFlight_ms_ \
-                    / sqrt( physConst::GAMMA_Air * physConst::R_Air * temperature_K );
+        machNumber_ = vFlight_ms_ / sqrt( physConst::GAMMA_Air * physConst::R_Air * temperature_K );
+    }
 
 
 } /* End of Aircraft::setVFlight */

--- a/Code.v05-00/src/Core/BoxModel.cpp
+++ b/Code.v05-00/src/Core/BoxModel.cpp
@@ -518,7 +518,7 @@ int BoxModel( const OptInput &Input_Opt, const Input &input )
             /* Clear dynamically allocated variable(s) */
             if ( sun != NULL )
                 sun->~SZA();
-            return KPP_FAIL;
+            return IERR;
         }
 
         ambientData.FillIn( nTime + 1 );

--- a/Code.v05-00/src/Core/Cluster.cpp
+++ b/Code.v05-00/src/Core/Cluster.cpp
@@ -144,7 +144,6 @@ Cluster::~Cluster( )
 void Cluster::ComputeRingAreas( const Vector_2D &cellAreas, const Vector_3D &weights ) 
 {
 
-    double currRingArea;
     UInt iNx, jNy, iRing;
 
     UInt size = 0;

--- a/Code.v05-00/src/Core/Diag_Mod.cpp
+++ b/Code.v05-00/src/Core/Diag_Mod.cpp
@@ -10,9 +10,13 @@
 /* File                 : Diag_Mod.cpp                              */
 /*                                                                  */
 /* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
-#include <format>
+#ifndef FMT_HEADER_ONLY
+#define FMT_HEADER_ONLY
+#endif
 
+#include <fmt/core.h>
 #include "Core/Diag_Mod.hpp"
+
 namespace Diag {
 
     static const NcType& varDataType = ncFloat;
@@ -153,10 +157,10 @@ namespace Diag {
         start_pos = 0; 
         found = 0;
 
-        // Make zero padded string representations with C++20 format
-        auto hh_string = std::format("{:02}", hh);
-        auto mm_string = std::format("{:02}", mm);
-        auto ss_string = std::format("{:02}", ss);
+        // Make zero padded string representations with fmt
+        auto hh_string = fmt::format("{:02}", hh);
+        auto mm_string = fmt::format("{:02}", mm);
+        auto ss_string = fmt::format("{:02}", ss);
 
         while ( (start_pos = fileName.find("hh", start_pos)) != std::string::npos ) {
             fileName.replace(start_pos, 2, hh_string);

--- a/Code.v05-00/src/Core/Diag_Mod.cpp
+++ b/Code.v05-00/src/Core/Diag_Mod.cpp
@@ -83,9 +83,9 @@ namespace Diag {
 
         /* Define conversion factor */
         double scalingFactor;
-        char charSpc[30];
-        char charName[50];
-        char charUnit[20];
+        std::string charSpc;
+        std::string charName;
+        std::string charUnit;
 
         // Define vector of dimensions
         std::vector<NcDim> xyDims{ yDim, xDim };
@@ -93,16 +93,20 @@ namespace Diag {
         std::vector<size_t> startp2( 2, 0 );
         std::vector<size_t> countp2{ m.Ny(), m.Nx() };
 
-        for ( UInt N = 0; N < NSPECALL; N++ ) {
+        // Provide type information for the variable defined by the KPP macro
+        // By default is casted as a UInt but we want int here for consistency
+        int NSpecAll = NSPECALL;
+
+        for ( int N = 0; N < NSpecAll; N++ ) {
             for ( UInt i = 0; i < speciesIndices.size(); i++ ) {
             
                 if ( speciesIndices[i] - 1 == N ) {
 
-                    strncpy( charSpc, SPC_NAMES[N], sizeof(charSpc) );
-                    strncpy( charName, SPC_NAMES[N], sizeof(charName) );
-                    strcat(  charName, " molecular concentration" );
+                    charSpc = SPC_NAMES[N];
+                    charName = SPC_NAMES[N];
+                    charName += " molecular concentration";
+                    charUnit = "molec/cm^3";
                     scalingFactor = 1.0E+00;
-                    strncpy( charUnit, "molec/cm^3", sizeof(charUnit) );
             
     #if ( SAVE_TO_DOUBLE )
                     array = util::vect2double( Data.Species[N], m.Ny(), m.Nx(), scalingFactor );

--- a/Code.v05-00/src/Core/Engine.cpp
+++ b/Code.v05-00/src/Core/Engine.cpp
@@ -66,7 +66,6 @@ Engine::Engine( const char *engineName, std::string engineFileName, double tempe
 
     std::vector<std::string> tokens;
     std::string token;
-    std::string::size_type sz;
     std::istringstream tokenStream;
 
     /* Idle */

--- a/Code.v05-00/src/Core/Input.cpp
+++ b/Code.v05-00/src/Core/Input.cpp
@@ -77,21 +77,17 @@ Input::Input( unsigned int iCase,               \
     simulationTime_( parameters[iCase].at("PLUMEPROCESS")),
     temperature_K_ ( parameters[iCase].at("TEMPERATURE")),
     relHumidity_w_ ( parameters[iCase].at("RHW")),
-    pressure_Pa_   ( parameters[iCase].at("PRESSURE")),
     horizDiff_     ( parameters[iCase].at("DH")),
     vertiDiff_     ( parameters[iCase].at("DV")),
     shear_         ( parameters[iCase].at("SHEAR")),
-    nBV_           ( parameters[iCase].at("NBV")),
+
     longitude_deg_ ( parameters[iCase].at("LONGITUDE")),
     latitude_deg_  ( parameters[iCase].at("LATITUDE")),
+    pressure_Pa_   ( parameters[iCase].at("PRESSURE")),
+
     emissionDOY_   ( parameters[iCase].at("EDAY")),
     emissionTime_  ( parameters[iCase].at("ETIME")),
-    backgNOx_      ( parameters[iCase].at("BACKG_NOX")),
-    backgHNO3_     ( parameters[iCase].at("BACKG_HNO3")),
-    backgO3_       ( parameters[iCase].at("BACKG_O3")),
-    backgCO_       ( parameters[iCase].at("BACKG_CO")),
-    backgCH4_      ( parameters[iCase].at("BACKG_CH4")),
-    backgSO2_      ( parameters[iCase].at("BACKG_SO2")),
+
     EI_NOx_        ( parameters[iCase].at("EI_NOX")),
     EI_CO_         ( parameters[iCase].at("EI_CO")),
     EI_HC_         ( parameters[iCase].at("EI_UHC")),
@@ -99,8 +95,17 @@ Input::Input( unsigned int iCase,               \
     EI_SO2TOSO4_   ( parameters[iCase].at("EI_SO2TOSO4")),
     EI_Soot_       ( parameters[iCase].at("EI_SOOT")),
     sootRad_       ( parameters[iCase].at("EI_SOOTRAD")),
+
     fuelFlow_      ( parameters[iCase].at("FF")),
     aircraftMass_  ( parameters[iCase].at("AMASS")),
+
+    backgNOx_      ( parameters[iCase].at("BACKG_NOX")),
+    backgHNO3_     ( parameters[iCase].at("BACKG_HNO3")),
+    backgO3_       ( parameters[iCase].at("BACKG_O3")),
+    backgCO_       ( parameters[iCase].at("BACKG_CO")),
+    backgCH4_      ( parameters[iCase].at("BACKG_CH4")),
+    backgSO2_      ( parameters[iCase].at("BACKG_SO2")),
+
     flightSpeed_   ( parameters[iCase].at("FSPEED")),
     numEngines_    ( parameters[iCase].at("NUMENG")),
     wingspan_      ( parameters[iCase].at("WINGSPAN")),
@@ -110,7 +115,10 @@ Input::Input( unsigned int iCase,               \
     fileName_ADJ_  ( fileName_ADJ ),
     fileName_BOX_  ( fileName_BOX ),
     fileName_micro_ ( fileName_micro ),
-    author_        ( author )
+    author_        ( author ),
+
+    nBV_           ( parameters[iCase].at("NBV"))
+
 {
 
 }

--- a/Code.v05-00/src/Core/LAGRIDPlumeModel.cpp
+++ b/Code.v05-00/src/Core/LAGRIDPlumeModel.cpp
@@ -4,12 +4,11 @@ LAGRIDPlumeModel::LAGRIDPlumeModel( const OptInput &optInput, const Input &input
     optInput_(optInput),
     input_(input),
     numThreads_(optInput.SIMULATION_OMP_NUM_THREADS),
-    simVars_(MPMSimVarsWrapper(input, optInput)),
     sun_(SZA(input.latitude_deg(), input.emissionDOY())),
-    timestepVars_(TimestepVarsWrapper(input, optInput)),
     aircraft_(Aircraft(input, optInput.SIMULATION_INPUT_ENG_EI)),
-    jetA_(Fuel("C12H24"))
-
+    jetA_(Fuel("C12H24")),
+    simVars_(MPMSimVarsWrapper(input, optInput)),
+    timestepVars_(TimestepVarsWrapper(input, optInput))
 {
     /* Multiply by 500 since it gets multiplied by 1/500 within the Emission object ... */ 
     jetA_.setFSC( input.EI_SO2() * 500.0 );
@@ -261,7 +260,7 @@ void LAGRIDPlumeModel::initializeGrid() {
     std::cout << "Initial Contrail Width: " << initWidth << std::endl;
     std::cout << "Initial Contrail Depth: " << initDepth << std::endl;
 
-    for (int n = 0; n < iceAerosol_.getNBin(); n++) {
+    for (UInt n = 0; n < iceAerosol_.getNBin(); n++) {
         double EPM_nPart_bin = epmIceAer.binMoment(n) * epmOut.area;
         double logBinRatio = log(iceAerosol_.getBinEdges()[n+1] / iceAerosol_.getBinEdges()[n]);
         //Start contrail at altitude -D1/2 to reflect the sinking.
@@ -292,13 +291,13 @@ void LAGRIDPlumeModel::initH2O() {
 
     auto areas = VectorUtils::cellAreas(xEdges_, yEdges_);
 
-    auto localPlumeEmission = [&](int j, int i) -> double {
+    auto localPlumeEmission = [&](std::size_t j, std::size_t i) -> double {
         if(mask[j][i] == 0) return 0;
         return E_H2O * 1.0E-06 / ( nonMaskCount * areas[j][i] );
     };
     //We could technically pre-compute all the masked indices and arrange them in a vector, but whatever.
-    for(int j = 0; j < mask.size(); j++) {
-        for(int i = 0; i < mask[0].size(); i++) {
+    for(std::size_t j = 0; j < mask.size(); j++) {
+        for(std::size_t i = 0; i < mask[0].size(); i++) {
             if(mask[j][i] == 1) {
                 double localPlumeH2O = localPlumeEmission(j, i);
                 H2O_[j][i] += localPlumeH2O;
@@ -319,8 +318,8 @@ void LAGRIDPlumeModel::updateDiffVecs() {
     diffCoeffY_ = Vector_2D(yCoords_.size(), Vector_1D(xCoords_.size()));
     
     #pragma omp parallel for
-    for(int j = 0; j < yCoords_.size(); j++) {
-        for(int i = 0; i < xCoords_.size(); i++) {
+    for(std::size_t j = 0; j < yCoords_.size(); j++) {
+        for(std::size_t i = 0; i < xCoords_.size(); i++) {
             diffCoeffX_[j][i] = number[j][i] > num_max * 1e-4 ? dh_enhanced : input_.horizDiff();
             diffCoeffY_[j][i] = number[j][i] > num_max * 1e-4 ? dv_enhanced : input_.vertiDiff();
         }
@@ -332,8 +331,8 @@ void LAGRIDPlumeModel::runTransport(double timestep) {
 
     //TODO: Implement height dependent shear. For now, just taking shear of y coordinate with highest xOD to avoid bugs.
     auto xOD = iceAerosol_.xOD(Vector_1D(xCoords_.size(), xCoords_[1] - xCoords_[0]));
-    double maxIdx = 0;
-    for (int i = 0; i < xOD.size(); i++) {
+    int maxIdx = 0;
+    for (std::size_t i = 0; i < xOD.size(); i++) {
         if(xOD[i] > xOD[maxIdx]) maxIdx = i;
     }
     shear_rep_ = met_.shear(maxIdx);
@@ -343,7 +342,7 @@ void LAGRIDPlumeModel::runTransport(double timestep) {
     updateDiffVecs();
     //Transport the Ice Aerosol PDF
     #pragma omp parallel for default(shared)
-    for ( int n = 0; n < iceAerosol_.getNBin(); n++ ) {
+    for ( UInt n = 0; n < iceAerosol_.getNBin(); n++ ) {
         /* Transport particle number and volume for each bin and
             * recompute centers of each bin for each grid cell
             * accordingly */
@@ -400,13 +399,11 @@ std::pair<LAGRID::twoDGridVariable,LAGRID::twoDGridVariable> LAGRIDPlumeModel::r
 void LAGRIDPlumeModel::remapAllVars(double remapTimestep) {
     //Generate free box grid from met post-advection
     Vector_2D iceTotalNum = iceAerosol_.TotalNumber();
-    double maxNum = VectorUtils::VecMax2D(iceTotalNum);
     auto numberMask = iceNumberMask();
     auto& mask = numberMask.first;
     auto& maskInfo = numberMask.second;
 
     Vector_3D& pdfRef = iceAerosol_.getPDF_nonConstRef();
-    Vector_3D& vCentersRef = iceAerosol_.getBinVCenters_nonConstRef();
     Vector_3D volume = iceAerosol_.Volume();
 
     double vertDiffLengthScale = sqrt(VectorUtils::VecMax2D(diffCoeffY_) * remapTimestep);
@@ -439,7 +436,7 @@ void LAGRIDPlumeModel::remapAllVars(double remapTimestep) {
 
     /* TODO: Benchmark various ways of parallelizing this section, mainly the volume calculation that requires a reduction */
     #pragma omp parallel for default(shared)
-    for(int n = 0; n < iceAerosol_.getNBin(); n++) {
+    for(UInt n = 0; n < iceAerosol_.getNBin(); n++) {
         //Update pdf and volume
         pdfRef[n] = remapVariable(maskInfo, buffers, pdfRef[n], mask).first.phi;
         volume[n] = remapVariable(maskInfo, buffers, volume[n], mask).first.phi;
@@ -528,8 +525,8 @@ double LAGRIDPlumeModel::totalAirMass() {
     double totalAirMass = 0;
     double cellArea = (xEdges_[1] - xEdges_[0]) * (yEdges_[1] - yEdges_[0]);
     double conversion_factor = 1.0e6 * MW_Air / physConst::Na; // molec/cm3 * cm3/m3 * kg/mol * mol/molec = kg/m3
-    for(int j = 0; j < yCoords_.size(); j++) {
-        for(int i = 0; i < xCoords_.size(); i++) {
+    for(std::size_t j = 0; j < yCoords_.size(); j++) {
+        for(std::size_t i = 0; i < xCoords_.size(); i++) {
             totalAirMass += mask[j][i] * met_.airMolecDens(j, i) * cellArea * conversion_factor;
         }
     }
@@ -539,15 +536,15 @@ double LAGRIDPlumeModel::totalAirMass() {
 void LAGRIDPlumeModel::runCocipH2OMixing(const Vector_2D& h2o_old, const Vector_2D& h2o_amb_new, MaskType& mask_old, MaskType& mask_new) {
     //h2o_old is the actual H2O field of the "before" timestep
     double molec_h2o_old = 0;
-    for (int j = 0; j < h2o_old.size(); j++) {
-        for (int i = 0; i < h2o_old[0].size(); i++) {
+    for (std::size_t j = 0; j < h2o_old.size(); j++) {
+        for (std::size_t i = 0; i < h2o_old[0].size(); i++) {
             molec_h2o_old += mask_old.first[j][i] * h2o_old[j][i];
         }
     }
     //h2o_amb_new is the *ambient met* H2O field of the next timestep
     double molec_h2o_amb_added = 0;
-    for (int j = 0; j < h2o_amb_new.size(); j++) {
-        for (int i = 0; i < h2o_amb_new[0].size(); i++) {
+    for (std::size_t j = 0; j < h2o_amb_new.size(); j++) {
+        for (std::size_t i = 0; i < h2o_amb_new[0].size(); i++) {
             molec_h2o_amb_added += (mask_new.first[j][i] == 1 && mask_old.first[j][i] == 0) * h2o_amb_new[j][i];
         }
     }
@@ -555,8 +552,8 @@ void LAGRIDPlumeModel::runCocipH2OMixing(const Vector_2D& h2o_old, const Vector_
     double molec_h2o_final = molec_h2o_old + molec_h2o_amb_added; // molec/cm3
     double average_amb_humidity_final = molec_h2o_final / mask_new.second.count;
 
-    for (int j = 0; j < H2O_.size(); j++)  {
-        for (int i = 0; i < H2O_[0].size(); i++) {
+    for (std::size_t j = 0; j < H2O_.size(); j++)  {
+        for (std::size_t i = 0; i < H2O_[0].size(); i++) {
             if(mask_new.first[j][i] == 1) {
                 H2O_[j][i] = average_amb_humidity_final;
             }

--- a/Code.v05-00/src/Core/LiquidAer.cpp
+++ b/Code.v05-00/src/Core/LiquidAer.cpp
@@ -94,7 +94,7 @@ unsigned int STRAT_AER( const double temperature_K     , const double pressure_P
     const double PSC_PMIN   =   5.0E+02;
 
     /* Peak pressure at which NAT can form homogeneously */
-    const double P_MAXNAT   =  1.40E+04; /* [Pa] */
+    // const double P_MAXNAT   =  1.40E+04; /* [Pa] */
 
     /* Maximum temperature for PSC formation */
     const double T_MAX = 215.0E+00; /* [K] */
@@ -113,7 +113,7 @@ unsigned int STRAT_AER( const double temperature_K     , const double pressure_P
     bool IS_POLAR, IS_STRAT, IS_VALID;
 
     /* Mass of dry air per grid box [m/mol] */
-    const double INVAIR = MW_Air / ( pressure_Pa / ( physConst::R_Air * temperature_K ) * Area ); 
+    // const double INVAIR = MW_Air / ( pressure_Pa / ( physConst::R_Air * temperature_K ) * Area ); 
     /* Unit check :
      * kg/mol / ( kg/m^3 * m^2 ) = m / mol*/
    
@@ -132,7 +132,8 @@ unsigned int STRAT_AER( const double temperature_K     , const double pressure_P
     double HCl_BOX_G   , HCl_BOX_L;
     double HOCl_BOX_G  , HOCl_BOX_L;
     double HBr_BOX_G   , HBr_BOX_L;
-    double HOBr_BOX_G  , HOBr_BOX_L;
+    // double HOBr_BOX_G  , HOBr_BOX_L;
+    double HOBr_BOX_L;
     double HNO3_GASFRAC, HCl_GASFRAC, HOCl_GASFRAC, \
            HBr_GASFRAC , HOBr_GASFRAC;
     double VOL_NAT, VOL_ICE, VOL_SLA, VOL_TOT;
@@ -198,7 +199,7 @@ unsigned int STRAT_AER( const double temperature_K     , const double pressure_P
     HOCl_BOX_L         = 0.0E+00;
     HBr_BOX_G          = 0.0E+00;
     HBr_BOX_L          = 0.0E+00;
-    HOBr_BOX_G         = 0.0E+00;
+    // HOBr_BOX_G         = 0.0E+00;
     HOBr_BOX_L         = 0.0E+00;
     HNO3_GASFRAC       = 0.0E+00;
     HCl_GASFRAC        = 0.0E+00;
@@ -573,7 +574,7 @@ unsigned int STRAT_AER( const double temperature_K     , const double pressure_P
         HOCl_BOX_L = HOClSUM - HOCl_BOX_G;
         HBr_BOX_G  = HBrSUM * HBr_GASFRAC;
         HBr_BOX_L  = HBrSUM - HBr_BOX_G;
-        HOBr_BOX_G = HOBrSUM * HOBr_GASFRAC;
+        // HOBr_BOX_G = HOBrSUM * HOBr_GASFRAC;
         HOBr_BOX_L = HOBrSUM - HBr_BOX_G;
 
         /* Calculate SLA parameters (Grainger 1995) */
@@ -762,7 +763,8 @@ std::vector<double> SLA_GAMMA( const double T_K         , const double P_Pa     
     double H2OPP;
     
     /* Partial pressures of HCl, HBr, HOBr, ClONO2, BrONO3 in atm */
-    double HClPP, HBrPP, HOBrPP, ClNO3PP, BrNO3PP;
+    // double HClPP, HBrPP, HOBrPP, ClNO3PP, BrNO3PP;
+    double HClPP, HOBrPP, ClNO3PP;
 
     /* Water vapor saturation pressure in Pa */
     double PSATH2O;
@@ -771,13 +773,14 @@ std::vector<double> SLA_GAMMA( const double T_K         , const double P_Pa     
     double ACTH2O;
 
     /* Molality of H2SO4 (mol H2SO4/kg solvent) */
-    double MOLAL;
+    // double MOLAL;
 
     /* Mass of H2SO4 */
     double M_H2SO4;
 
     /* HOBr parameters */
-    double c_HOBr, SHOBr, HHOBr, DHOBr, kHOBr_HCl, GHOBrrxn, lHOBr, fHOBr, gHOBr_HCl;
+    // double c_HOBr, SHOBr, HHOBr, DHOBr, kHOBr_HCl, GHOBrrxn, lHOBr, fHOBr, gHOBr_HCl;
+    double c_HOBr, HHOBr, DHOBr, kHOBr_HCl, GHOBrrxn, lHOBr, fHOBr, gHOBr_HCl;
 
     /* HOCl parameters */
     double c_HOCl, SHOCl, HHOCl, DHOCl, kHOCl_HCl, GHOClrxn, lHOCl, fHOCl, gHOCl_HCl;
@@ -789,7 +792,8 @@ std::vector<double> SLA_GAMMA( const double T_K         , const double P_Pa     
     std::vector<double> AK( 3, 0.0 );
 
     /* Other parameters */
-    double kH2O, kH, khdr, GbH2O, HHCl, MHCl, kHCl, GbHCl, Gs, FHCl, Gsp, GbHClp, Gb, khydr, kII, k_dl;
+    // double kH2O, kH, khdr, GbH2O, HHCl, MHCl, kHCl, GbHCl, Gs, FHCl, Gsp, GbHClp, Gb, khydr, kII, k_dl;
+    double kH2O, kH, GbH2O, HHCl, MHCl, kHCl, GbHCl, Gs, FHCl, Gsp, GbHClp, Gb, khydr, kII, k_dl;
 
     /* Interim variables */
     double X, A, H, T_THRESHOLD, aH;
@@ -803,16 +807,16 @@ std::vector<double> SLA_GAMMA( const double T_K         , const double P_Pa     
     WT          = 0.0E+00;
     H2OPP       = 0.0E+00;
     HClPP       = 0.0E+00;
-    HBrPP       = 0.0E+00;
+    // HBrPP       = 0.0E+00;
     HOBrPP      = 0.0E+00;
     ClNO3PP     = 0.0E+00;
-    BrNO3PP     = 0.0E+00;
+    // BrNO3PP     = 0.0E+00;
     PSATH2O     = 0.0E+00;
     ACTH2O      = 0.0E+00;
-    MOLAL       = 0.0E+00;
+    // MOLAL       = 0.0E+00;
     M_H2SO4     = 0.0E+00;
     c_HOBr      = 0.0E+00;
-    SHOBr       = 0.0E+00;
+    // SHOBr       = 0.0E+00;
     HHOBr       = 0.0E+00;
     DHOBr       = 0.0E+00;
     kHOBr_HCl   = 0.0E+00;
@@ -841,7 +845,7 @@ std::vector<double> SLA_GAMMA( const double T_K         , const double P_Pa     
     gClNO3_H2O  = 0.0E+00;
     kH2O        = 0.0E+00;
     kH          = 0.0E+00;
-    khdr        = 0.0E+00;
+    // khdr        = 0.0E+00;
     GbH2O       = 0.0E+00;
     HHCl        = 0.0E+00;
     MHCl        = 0.0E+00;
@@ -875,7 +879,7 @@ std::vector<double> SLA_GAMMA( const double T_K         , const double P_Pa     
 
     /* Calculate molality of solution */
     WT = 1.00E+02 * WT_FRC; /* Convert from fraction to % */
-    MOLAL = 1.0E+03 * ( WT / 9.80E+01 / ( 1.00E+02 - WT ) );
+    // MOLAL = 1.0E+03 * ( WT / 9.80E+01 / ( 1.00E+02 - WT ) );
 
     /* Parameters for H2SO4 solution
      * The solution density is calculated earlier, including
@@ -903,7 +907,7 @@ std::vector<double> SLA_GAMMA( const double T_K         , const double P_Pa     
     /* All the following partial pressures are computed in atm */
     HClPP   = HClSUM   * P_Pa / physConst::ATM;
     ClNO3PP = ClNO3SUM * P_Pa / physConst::ATM;
-    BrNO3PP = BrNO3SUM * P_Pa / physConst::ATM;
+    // BrNO3PP = BrNO3SUM * P_Pa / physConst::ATM;
     HOBrPP  = HOBrSUM  * P_Pa / physConst::ATM;
  
     /* Should we bother running calculations? */
@@ -1006,7 +1010,7 @@ std::vector<double> SLA_GAMMA( const double T_K         , const double P_Pa     
      /* Reaction 10. HOBr + HCl */
      if ( ( HClOK ) && ( HOBrOK ) ) {
          c_HOBr    =  physFunc::thermalSpeed( T_K , 9.691E+01 );
-         SHOBr     =  7.76E-02 + 5.918E+01 / T_K;
+        //  SHOBr     =  7.76E-02 + 5.918E+01 / T_K;
          HHOBr     =  exp( -9.86E+00 + 5.427E+03 / T_K );
          DHOBr     =  1.00E-08;
          kII       =  exp( 1.54E+02 - 1.63E+00 * WT ) * exp( -( 3.85E+04 - 4.78E+02 * WT ) / T_K );

--- a/Code.v05-00/src/Core/MPMSimVarsWrapper.cpp
+++ b/Code.v05-00/src/Core/MPMSimVarsWrapper.cpp
@@ -22,6 +22,7 @@ MPMSimVarsWrapper::MPMSimVarsWrapper(const Input& input, const OptInput& Input_O
 	LIQ_COAG(Input_Opt.AEROSOL_COAGULATION_LIQUID),
 	ICE_GROWTH(Input_Opt.AEROSOL_ICE_GROWTH),
 	TEMP_PERTURB(Input_Opt.MET_ENABLE_TEMP_PERTURB),
+	metDepth(Input_Opt.MET_DEPTH),
 	DIAG_FILENAME(Input_Opt.DIAG_FILENAME),
 	TS_FOLDER(Input_Opt.SIMULATION_OUTPUT_FOLDER),
 	TS_SPEC(Input_Opt.TS_SPEC),
@@ -36,8 +37,7 @@ MPMSimVarsWrapper::MPMSimVarsWrapper(const Input& input, const OptInput& Input_O
 	SAVE_O3PL(Input_Opt.PL_O3),
 	temperature_K(input.temperature_K()),
 	pressure_Pa(input.pressure_Pa()),
-	relHumidity_w(input.relHumidity_w()),
-	metDepth(Input_Opt.MET_DEPTH)
+	relHumidity_w(input.relHumidity_w())
 
 
 {

--- a/Code.v05-00/src/Core/Main.cpp
+++ b/Code.v05-00/src/Core/Main.cpp
@@ -30,7 +30,6 @@
 #include "Core/LAGRIDPlumeModel.hpp"
 #include "Core/Status.hpp"
 
-static int DIR_FAIL = -9;
 
 void CreateREADME( const std::string folder, const std::string fileName, \
                    const std::string purpose );
@@ -49,7 +48,9 @@ int main( int argc, char* argv[])
 {
 
     std::vector<std::unordered_map<std::string, double> > parameters;
-    unsigned int iCase, nCases;
+    unsigned int iCase;
+    // Help compiler tell this variable is initialized
+    unsigned int nCases = 0;
     const unsigned int iOFFSET = 0;
     
     const unsigned int model = 1;
@@ -102,6 +103,14 @@ int main( int argc, char* argv[])
 
         /* Number of cases */
         nCases  = parameters.size();
+        
+        /* Ensure cases were created properly */
+        if (nCases == 0)
+        {
+            std::cout << "Failed generating cases from input file" << std::endl;
+            std::cout << "Exiting ... " << std::endl;
+            exit(1);
+        }
         
         /* Create output directory */
         struct stat sb;
@@ -307,6 +316,7 @@ int main( int argc, char* argv[])
 
 } /* End of Main */
 
+// TODO rewrite all of this with std::filesystem
 void CreateREADME( const std::string folder, const std::string fileName, const std::string purpose )
 {
 
@@ -362,8 +372,8 @@ void CreateREADME( const std::string folder, const std::string fileName, const s
     README << "\n## Simulation start date " << buffer << "\n";
 
     /* Print source code directory */
-    char cwd[PATH_MAX];
-    getcwd(cwd, sizeof(cwd));
+    // Calling with args (NULL, 0) allocates a new buffer of the correct size
+    char *cwd = getcwd(NULL, 0);
     if ( cwd != NULL )
         README << "\n## Source files: " << cwd << "\n";
     else

--- a/Code.v05-00/src/Core/Mesh.cpp
+++ b/Code.v05-00/src/Core/Mesh.cpp
@@ -14,21 +14,22 @@
 #include "Core/Mesh.hpp"
 
 Mesh::Mesh(const OptInput& optInput):
-   nx( optInput.ADV_GRID_NX ),
-   ny( optInput.ADV_GRID_NY ),
-   xlim_right( optInput.ADV_GRID_XLIM_RIGHT ),
-   xlim_left( optInput.ADV_GRID_XLIM_LEFT ),
-   ylim_up( optInput.ADV_GRID_YLIM_UP ),
-   ylim_down( optInput.ADV_GRID_YLIM_DOWN ){
+    xlim_right( optInput.ADV_GRID_XLIM_RIGHT ),
+    xlim_left( optInput.ADV_GRID_XLIM_LEFT ),
+    ylim_up( optInput.ADV_GRID_YLIM_UP ),
+    ylim_down( optInput.ADV_GRID_YLIM_DOWN ),
+    nx( optInput.ADV_GRID_NX ),
+    ny( optInput.ADV_GRID_NY )
+{
     initCoordVectors(MeshDomainLimitsSpec::CENTERED_LIMITS);
 }
 Mesh::Mesh(int nx, int ny, double xlim_left, double xlim_right, double ylim_up, double ylim_down, MeshDomainLimitsSpec limitsSpec):
-   nx( nx ),
-   ny( ny ),
-   xlim_right( xlim_right ),
-   xlim_left( xlim_left ),
-   ylim_up( ylim_up ),
-   ylim_down( ylim_down )
+    xlim_right( xlim_right ),
+    xlim_left( xlim_left ),
+    ylim_up( ylim_up ),
+    ylim_down( ylim_down ),
+    nx( nx ),
+    ny( ny )
 {
     initCoordVectors(limitsSpec);
 
@@ -333,7 +334,7 @@ void Mesh::MapWeights( )
 } /* End of Mesh::MapWeights */
 
 void Mesh::updateVertGrid( const Vector_1D& yE_new ) {
-    for(int i = 0; i < yE_new.size(); i++) {
+    for(std::size_t i = 0; i < yE_new.size(); i++) {
         y_[i] = (yE_new[i] + yE_new[i+1]) / 2;
         dy_[i] = yE_new[i+1] - yE_new[i];
     }

--- a/Code.v05-00/src/Core/PlumeModel.cpp
+++ b/Code.v05-00/src/Core/PlumeModel.cpp
@@ -12,7 +12,7 @@
 /* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
 
-static int SUCCESS     =  1;
+// static int SUCCESS     =  1;
 
 /* STL includes */
 #include <iostream>
@@ -70,7 +70,7 @@ static int SUCCESS     =  1;
 /* (URGENT) FIXME: Whoever works on chemistry, REFACTOR THESE REMAINING GLOBAL VARIABLES by refactoring!
             Using non-const global variables is the biggest software engineering antipattern ever */
 int isSaved = 1;
-static int SAVE_FAIL   = -2;
+// static int SAVE_FAIL   = -2;
 
 double RCONST[NREACT];       /* Rate constants (global) */
 double NOON_JRATES[NPHOTOL]; /* Noon-time photolysis rates (global) */
@@ -151,8 +151,8 @@ SimStatus PlumeModel( OptInput &Input_Opt, const Input &input )
     }
 
     /* Grid indices */
-    UInt iNx = 0;
-    UInt jNy = 0;
+    int iNx;
+    int jNy;
 
     /* Species index */
     UInt N   = 0;
@@ -313,7 +313,7 @@ SimStatus PlumeModel( OptInput &Input_Opt, const Input &input )
 
     /* Allocate shear */
     double shear;
-    int LASTINDEX_SHEAR;
+    // int LASTINDEX_SHEAR;
 
     /* Initialize */
     d_x = 0;       /* [m2/s] */
@@ -326,10 +326,10 @@ SimStatus PlumeModel( OptInput &Input_Opt, const Input &input )
     D_X   = input.horizDiff(); /* [m^2/s] */
     D_Y   = input.vertiDiff(); /* [m^2/s] */
     shear = Met.shear();     /* [1/s] */
-    if ( shear >= 0.0E+00 )
-        LASTINDEX_SHEAR = Input_Opt.ADV_GRID_NX - 1;
-    else
-        LASTINDEX_SHEAR = 0;
+    // if ( shear >= 0.0E+00 )
+    //     LASTINDEX_SHEAR = Input_Opt.ADV_GRID_NX - 1;
+    // else
+    //     LASTINDEX_SHEAR = 0;
 
     /* ======================================================================= */
     /* ----------------------------------------------------------------------- */
@@ -383,6 +383,9 @@ SimStatus PlumeModel( OptInput &Input_Opt, const Input &input )
 
     /* Allocate doubles to store RH and IWC */
     double relHumidity, IWC;
+
+    // Initialize IWC to help compiler, value will be overwritten before it is used.
+    IWC = 0;
 
     /* Initialize tolerances */
     for( UInt i = 0; i < NVAR; i++ ) {
@@ -447,8 +450,8 @@ SimStatus PlumeModel( OptInput &Input_Opt, const Input &input )
         iceAer.scalePdf( iceNumFrac );
     }
 
-    const double semiYaxis = 0.5 * aircraft.deltaz1();
-    const double semiXaxis = areaPlume / ( physConst::PI * semiYaxis );
+    // const double semiYaxis = 0.5 * aircraft.deltaz1();
+    // const double semiXaxis = areaPlume / ( physConst::PI * semiYaxis );
 
     //Initializes/Calculates TRANSPORT_PA, TRANSPORT_LA
     simVars.initMicrophysicsVars(Data, liquidAer, Ice_den);
@@ -607,30 +610,32 @@ SimStatus PlumeModel( OptInput &Input_Opt, const Input &input )
          * NY x NX x NFAM in [molec/cm^3/s]
          * into netCDF files at a frequency specified by the input file */
 
-        int hh = (int) (timestepVars.curr_Time_s - timestepVars.timeArray[0])/3600;
-        int mm = (int) (timestepVars.curr_Time_s - timestepVars.timeArray[0])/60   - 60 * hh;
-        int ss = (int) (timestepVars.curr_Time_s - timestepVars.timeArray[0])      - 60 * ( mm + 60 * hh );
-//        Diag_PL( "PL_hhmmss.nc", hh, mm, ss, Data, m );
+        // int hh = (int) (timestepVars.curr_Time_s - timestepVars.timeArray[0])/3600;
+        // int mm = (int) (timestepVars.curr_Time_s - timestepVars.timeArray[0])/60   - 60 * hh;
+        // int ss = (int) (timestepVars.curr_Time_s - timestepVars.timeArray[0])      - 60 * ( mm + 60 * hh );
+        // Diag_PL( "PL_hhmmss.nc", hh, mm, ss, Data, m );
 
     } else {
         if ( simVars.SAVE_O3PL ) {
         }
     }
         /* Fill with? */
-    const double fillWith = 0.0E+00;
+    // const double fillWith = 0.0E+00;
 
     /* Allocate Solvers */
-    // SANDS::Solver Solver;
-    // #pragma omp critical
-    // {
-    //     std::cout << "\n Initializing solver..." << std::endl;
-    //     Solver.Initialize( /* Use threaded FFT?    */ simVars.THREADED_FFT, \
-    //                        /* Use FFTW wisdom?     */ simVars.USE_WISDOM,   \
-    //                        /* FFTW Directory       */ simVars.FFTW_DIR.c_str(),     \
-    //                        /* Fill negative values */ simVars.FILLNEG,      \
-    //                        /* Fill with this value */ fillWith );
-    //     std::cout << "\n Initialization complete..." << std::endl;
-    // }
+    /*
+    SANDS::Solver Solver;
+    #pragma omp critical
+    {
+        std::cout << "\n Initializing solver..." << std::endl;
+        Solver.Initialize(  simVars.THREADED_FFT,
+                            simVars.USE_WISDOM,   \
+                            simVars.FFTW_DIR.c_str(),     \
+                            simVars.FILLNEG,      \
+                            fillWith );
+        std::cout << "\n Initialization complete..." << std::endl;
+    }
+    */
     const FVM_ANDS::AdvDiffParams fvmSolverInitParams(0, 0, shear, D_X, D_Y, timestepVars.TRANSPORT_DT);
     const FVM_ANDS::BoundaryConditions H2O_BOUNDARY_COND = FVM_ANDS::bcFrom2DVector(Data.Species[ind_H2Oplume]);
     const FVM_ANDS::BoundaryConditions ZERO_BOUNDARY_COND = FVM_ANDS::bcFrom2DVector(Data.Species[ind_H2Oplume], true);
@@ -758,7 +763,7 @@ SimStatus PlumeModel( OptInput &Input_Opt, const Input &input )
                 /* Transport of solid aerosols */
 
                 #pragma omp parallel for if(!PARALLEL_CASES) default(shared)
-                for ( int iBin_PA = 0; iBin_PA < Data.nBin_PA; iBin_PA++ ) {
+                for ( UInt iBin_PA = 0; iBin_PA < Data.nBin_PA; iBin_PA++ ) {
                     /* Transport particle number and volume for each bin and
                      * recompute centers of each bin for each grid cell
                      * accordingly */
@@ -963,6 +968,9 @@ SimStatus PlumeModel( OptInput &Input_Opt, const Input &input )
                 relHumidity = VAR[ind_H2O] * \
                                 physConst::kB * simVars.temperature_K * 1.00E+06 / \
                                 physFunc::pSat_H2Ol( simVars.temperature_K );
+
+                // IWC value here is still set from IWC = Data.solidAerosol.Moment( 3, Input_Opt.ADV_GRID_NY - 1, Input_Opt.ADV_GRID_NX - 1 ) * physConst::RHO_ICE;
+                // This does not seem correct but this is dead code... Value is definitely initialized however and not equal to 0 from the initial declaration.
                 GC_SETHET( simVars.temperature_K, simVars.pressure_Pa, airDens, relHumidity, \
                             Data.STATE_PSC, VAR, AerosolArea, AerosolRadi, IWC, &(Data.KHETI_SLA[0]), Input_Opt.ADV_TROPOPAUSE_PRESSURE );
             }

--- a/Code.v05-00/src/Core/ReadJRates.cpp
+++ b/Code.v05-00/src/Core/ReadJRates.cpp
@@ -21,7 +21,7 @@ void ReadJRates( const char* ROOTDIR,                          \
 {
 
     /* Set up for error messages */
-    static const int NC_ERR = 2;
+    // static const int NC_ERR = 2;
 
     std::string fullPath;
     std::stringstream mm, dd;

--- a/Code.v05-00/src/Core/ReadJRates.cpp
+++ b/Code.v05-00/src/Core/ReadJRates.cpp
@@ -70,6 +70,12 @@ void ReadJRates( const char* ROOTDIR,                          \
     bool LON_EDGE = 0;
     double LON_LOW, LON_HIGH;
 
+    /*
+    Initialize LON_LOW to help compiler understand it's never uninitialized when used
+    This value will be overwritten before LON_LOW is called
+    */
+    LON_LOW = 0; 
+
     if ( ( LON_INDEX == 0 ) || ( LON_INDEX + 1 == LON_SIZE ) )
         LON_EDGE = 1;
 

--- a/Code.v05-00/src/Core/Species.cpp
+++ b/Code.v05-00/src/Core/Species.cpp
@@ -137,8 +137,6 @@ SpeciesArray& SpeciesArray::operator+( const SpeciesArray &sp )
 SpeciesArray& SpeciesArray::operator-( const SpeciesArray &sp )
 {
 
-    UInt iRing, iTime, N;
-
     if ( nRing != sp.getnRing() ) {
         std::cout << "Can't perform + on SpeciesArray: nRing exception: " << nRing << " != " << sp.nRing << std::endl;
         return *this;
@@ -151,7 +149,7 @@ SpeciesArray& SpeciesArray::operator-( const SpeciesArray &sp )
 
     for ( UInt iRing = 0; iRing < nRing; iRing++ ) {
         for ( UInt iTime = 0; iTime < nTime; iTime++ ) {
-            for ( N = 0; N < NSPECREACT; N++ )
+            for ( UInt N = 0; N < NSPECREACT; N++ )
                 Species[N][iTime][iRing] -= sp.Species[N][iTime][iRing];
 
             sootDens[iTime][iRing] -= sp.sootDens[iTime][iRing];

--- a/Code.v05-00/src/Core/Structure.cpp
+++ b/Code.v05-00/src/Core/Structure.cpp
@@ -842,7 +842,10 @@ void Solution::getAerosolProp( double ( &radi )[4], \
 
 } /* End of Solution::getAerosolProp */
 
-int Solution::SpinUp( Vector_1D &amb_Value,       \
+/* 
+No functions check the return code of this function, temp fix is to return void
+*/
+void Solution::SpinUp( Vector_1D &amb_Value,       \
                       const Input &input,         \
                       const double airDens,   \
                       const double startTime, \
@@ -947,7 +950,7 @@ int Solution::SpinUp( Vector_1D &amb_Value,       \
                 }
             }
 
-            return KPP_FAIL;
+            // return KPP_FAIL;
         }
 
         curr_Time_s += DT_CHEM;
@@ -957,7 +960,7 @@ int Solution::SpinUp( Vector_1D &amb_Value,       \
     for ( UInt iVar = 0; iVar < NVAR; iVar++ )
         amb_Value[iVar] = varSpeciesArray[iVar] / airDens;
 
-    return IERR;
+    // return IERR;
 
 } /* End of Solution::SpinUp */
 

--- a/Code.v05-00/src/Core/Structure.cpp
+++ b/Code.v05-00/src/Core/Structure.cpp
@@ -522,7 +522,7 @@ void Solution::addEmission( const Emission &EI, const Aircraft &AC,        \
     double w;
     double E_CO2, E_H2O, E_NO, E_NO2, E_HNO2, E_SO2, E_CO, E_CH4, E_C2H6, \
                E_PRPE, E_ALK4, E_CH2O, E_ALD2, E_GLYX, E_MGLY;
-    double E_Soot;
+    // double E_Soot;
     const double rad = EI.getSootRad();
     const double fuelPerDist = AC.FuelFlow() / AC.VFlight();
 
@@ -551,7 +551,7 @@ void Solution::addEmission( const Emission &EI, const Aircraft &AC,        \
     E_SO2  = ( 1.0 - SO2TOSO4 ) * \
              EI.getSO2()  / ( MW_SO2  * 1.0E+03 ) * fuelPerDist * physConst::Na;
 
-    E_Soot = EI.getSoot() / ( 4.0 / 3.0 * physConst::PI * physConst::RHO_SOOT * 1.00E+03 * rad * rad * rad ) * fuelPerDist;
+    // E_Soot = EI.getSoot() / ( 4.0 / 3.0 * physConst::PI * physConst::RHO_SOOT * 1.00E+03 * rad * rad * rad ) * fuelPerDist;
     /*     = [g_soot/kg_fuel]/ (                        * [kg_soot/m^3]       * [g/kg]   * [m^3]           ) * [kg_fuel/m]
      *     = [part/m]
      */

--- a/Code.v05-00/src/EPM/Integrate.cpp
+++ b/Code.v05-00/src/EPM/Integrate.cpp
@@ -67,33 +67,17 @@ namespace EPM
                          const bool CHEMISTRY, double ambientLapseRate, std::string micro_data_out )
     {
     
-        double relHumidity_i_Amb, relHumidity_i_postVortex, relHumidity_i_Final;
+        double relHumidity_i_Final;
 
         /* relHumidity_w is in % */
-        relHumidity_i_Amb        = relHumidity_w * physFunc::pSat_H2Ol( temperature_K ) \
-                                                 / physFunc::pSat_H2Os( temperature_K ) / 100.0;
-        relHumidity_i_postVortex = relHumidity_w * physFunc::pSat_H2Ol( temperature_K + delta_T_ad ) \
-                                                 / physFunc::pSat_H2Os( temperature_K + delta_T_ad ) / 100.0;
         relHumidity_i_Final      = relHumidity_w * physFunc::pSat_H2Ol( temperature_K + delta_T ) \
                                                  / physFunc::pSat_H2Os( temperature_K + delta_T ) / 100.0;
 
         
-        double partPHNO3_Hom, partPHNO3_Het, satHNO3_Hom, satHNO3_Het;
         double final_Temp = temperature_K + delta_T;
-        double offset_Temp = final_Temp + T_NAT_SUPERCOOL; // NAT = Nitric acid trihydrate
 
         /* Homogeneous NAT, using supercooling requirement *
          * Heterogeneous NAT, no supercooling requirement */
-        partPHNO3_Hom = varArray[ind_HNO3] * physConst::kB * offset_Temp * 1.00E+06;
-        partPHNO3_Het = varArray[ind_HNO3] * physConst::kB * final_Temp  * 1.00E+06;
-        if ( relHumidity_i_Amb > 1.0 ) {
-            /* partPH2O = pSat_H2Os( temperature_K ) */
-            satHNO3_Hom = partPHNO3_Hom / physFunc::pSat_HNO3( offset_Temp, physFunc::pSat_H2Os( final_Temp ));
-            satHNO3_Het = partPHNO3_Het / physFunc::pSat_HNO3( final_Temp , physFunc::pSat_H2Os( final_Temp ));
-        } else {
-            satHNO3_Hom = partPHNO3_Hom / physFunc::pSat_HNO3( offset_Temp, relHumidity_i_Final * physFunc::pSat_H2Os( final_Temp ) );
-            satHNO3_Het = partPHNO3_Het / physFunc::pSat_HNO3( final_Temp , relHumidity_i_Final * physFunc::pSat_H2Os( final_Temp ) );
-        }
         
         /* Number of SO4 size distribution bins based on specified min and max radii *
         * and volume ratio between two adjacent bins */
@@ -501,7 +485,7 @@ namespace EPM
         double currTimeStep;
 
         /* Dilution factor */
-        double dilFactor, dilFactor_b;
+        // double dilFactor, dilFactor_b;
 
         /* Freshly nucleated aerosol characteristics */
         double SO4l, SO4l_b, T_b, P_b, n_air_prev, n_air;
@@ -527,11 +511,11 @@ namespace EPM
 
             /* Get dilution factor */
             if ( iTime == 0 ) {
-                dilFactor_b = 1.0;
+                // dilFactor_b = 1.0;
                 SO4l_b = 0.0;
             }
             else {
-                dilFactor_b = observer.m_states[observer.m_states.size()-1][EPM_ind_Trac];
+                // dilFactor_b = observer.m_states[observer.m_states.size()-1][EPM_ind_Trac];
                 SO4l_b = observer.m_states[observer.m_states.size()-1][EPM_ind_SO4l];
                 T_b = observer.m_states[observer.m_states.size()-1][EPM_ind_T];
                 P_b = observer.m_states[observer.m_states.size()-1][EPM_ind_P];
@@ -545,11 +529,11 @@ namespace EPM
                 totSteps += boost::numeric::odeint::integrate( rhs, x, timeArray[iTime], timeArray[iTime+1], currTimeStep/100.0, observer );
             }
             
-            dilFactor = observer.m_states[observer.m_states.size()-1][EPM_ind_Trac] / dilFactor_b;
+            // dilFactor = observer.m_states[observer.m_states.size()-1][EPM_ind_Trac] / dilFactor_b;
             SO4l = observer.m_states[observer.m_states.size()-1][EPM_ind_SO4l] ;
 
             n_air = physConst::Na * x[EPM_ind_P]/(physConst::R * x[EPM_ind_T] * 1.0e6);
-            n_air_prev = physConst::Na *  P_b/(physConst::R * T_b * 1.0e6);
+            n_air_prev = physConst::Na *  P_b/(physConst::R * T_b * 1.0e6);  // P_b and T_b seems to be used uninitialized during the first timestep with iTime = 0
 
             nPDF_new = ( SO4l*n_air - SO4l_b*n_air_prev);
 

--- a/Code.v05-00/src/EPM/Integrate.cpp
+++ b/Code.v05-00/src/EPM/Integrate.cpp
@@ -513,6 +513,8 @@ namespace EPM
             if ( iTime == 0 ) {
                 // dilFactor_b = 1.0;
                 SO4l_b = 0.0;
+                T_b = Tc0; // Set initial temperature in plume to core exit temp
+                P_b = pressure_Pa; // Set initial pressure in plume to ambient pressure
             }
             else {
                 // dilFactor_b = observer.m_states[observer.m_states.size()-1][EPM_ind_Trac];

--- a/Code.v05-00/src/EPM/odeSolver.cpp
+++ b/Code.v05-00/src/EPM/odeSolver.cpp
@@ -354,7 +354,7 @@ namespace EPM
     {
 
         /* Variable definitions */
-        int counter = 0;
+        std::size_t counter = 0;
         float RHw;
         bool watersup { false };
 

--- a/Code.v05-00/src/FVM_ANDS/AdvDiffSystem.cpp
+++ b/Code.v05-00/src/FVM_ANDS/AdvDiffSystem.cpp
@@ -10,19 +10,19 @@ namespace FVM_ANDS{
         v_double_ (params.v),
         shear_ (params.shear),
         dt_ (params.dt),
-        bcType_top_ (bc.bcType_top),
-        bcType_left_ (bc.bcType_left),
-        bcType_bot_ (bc.bcType_bot),
-        bcType_right_ (bc.bcType_right),
-        bcVals_top_ (bc.bcVals_top),
-        bcVals_left_ (bc.bcVals_left),
-        bcVals_bot_ (bc.bcVals_bot),
-        bcVals_right_ (bc.bcVals_right),
         dx_ (xCoords[1] - xCoords[0]),
         dy_ (yCoords[1] - yCoords[0]),
         nx_ (xCoords.size()),
         ny_ (yCoords.size()),
         yCoord_(yCoords),
+        bcType_top_ (bc.bcType_top),
+        bcType_left_ (bc.bcType_left),
+        bcType_right_ (bc.bcType_right),
+        bcType_bot_ (bc.bcType_bot),
+        bcVals_top_ (bc.bcVals_top),
+        bcVals_left_ (bc.bcVals_left),
+        bcVals_right_ (bc.bcVals_right),
+        bcVals_bot_ (bc.bcVals_bot),
         phi_(phi_init)
     {
         invdx_ = 1.0/dx_;
@@ -318,6 +318,8 @@ namespace FVM_ANDS{
                         case FaceDirection::WEST:
                             rhs_[i] += u_vec_[i] * dt_ / dx_ * points_[i]->bcVal();
                             break;
+                        case FaceDirection::ERROR:
+                            throw std::runtime_error("Invalid FaceDirection in Dirichlet boundary condition");
                     }
                     if (!points_[i]->secondBoundaryConds()) break;
                     BoundaryCondDescription bc_2 = points_[i]->secondBoundaryConds().value();

--- a/Code.v05-00/src/FVM_ANDS/FVM_Solver.cpp
+++ b/Code.v05-00/src/FVM_ANDS/FVM_Solver.cpp
@@ -9,7 +9,6 @@ namespace FVM_ANDS{
         solver_.setMaxIterations(maxIters_);
 
         //For SOR solves only, normally Eigen solvers come pre-packed with diagonal preconditioner.
-        int numTotalPoints = advDiffSys_.getCoefMatrix().rows();
         if(useDiagPreCond_){
             auto diagonalVec = advDiffSys_.getCoefMatrix().diagonal();
             auto diagonalMat = diagonalVec.asDiagonal();

--- a/Code.v05-00/src/FVM_ANDS/FVM_Solver.cpp
+++ b/Code.v05-00/src/FVM_ANDS/FVM_Solver.cpp
@@ -1,9 +1,9 @@
 #include "FVM_ANDS/FVM_Solver.hpp"
 namespace FVM_ANDS{
     FVM_Solver::FVM_Solver(const AdvDiffParams& params, const Vector_1D xCoords, const Vector_1D yCoords, const BoundaryConditions& bc, const Eigen::VectorXd& phi_init, bool useDiagPreCond, int maxIters, double convergenceThres)
-    :   advDiffSys_(AdvDiffSystem(params, xCoords, yCoords, bc, phi_init)),
-        maxIters_(maxIters),
+    :   maxIters_(maxIters),
         convergenceThres_(convergenceThres),
+        advDiffSys_(AdvDiffSystem(params, xCoords, yCoords, bc, phi_init)),
         useDiagPreCond_(useDiagPreCond){
         solver_.setTolerance(convergenceThres_);
         solver_.setMaxIterations(maxIters_);

--- a/Code.v05-00/src/KPP/KPP_LinearAlgebra.cpp
+++ b/Code.v05-00/src/KPP/KPP_LinearAlgebra.cpp
@@ -27,6 +27,10 @@
 #include "KPP/KPP_Global.h"
 #include "KPP/KPP_Sparse.h"
 
+// Ignore compiler warning in auto-generated code
+// Warning is restored at the end of the file
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 
 /* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 /*                                                                  */
@@ -1921,4 +1925,4 @@ void WADD(int N, double X[], double Y[], double Z[])
 /* End of BLAS_UTIL function                                        */
 /* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
-
+#pragma GCC diagnostic pop

--- a/Code.v05-00/src/KPP/KPP_Main_ADJ.cpp
+++ b/Code.v05-00/src/KPP/KPP_Main_ADJ.cpp
@@ -556,7 +556,7 @@ int KPP_Main_ADJ( const double finalPlume[], const double initBackg[],  \
                         && ( VAR_INIT[ind_NO] > 0.0E+00 ) \
                         && ( VAR_INIT[ind_NO2] > 0.0E+00 ) \
                         && ( VAR_INIT[ind_O3] > 0.0E+00 ) \
-                        && ( VAR_INIT[ind_HNO3] > 0.0E+00 ) \ 
+                        && ( VAR_INIT[ind_HNO3] > 0.0E+00 ) \
                         && ( VAR_RUN[ind_NO] > 0.0E+00 ) \
                         && ( VAR_RUN[ind_NO2] > 0.0E+00 ) \
                         && ( VAR_RUN[ind_O3] > 0.0E+00 ) \

--- a/Code.v05-00/src/LAGRID/FreeCoordBoxGrid.cpp
+++ b/Code.v05-00/src/LAGRID/FreeCoordBoxGrid.cpp
@@ -1,16 +1,16 @@
 #include "LAGRID/FreeCoordBoxGrid.hpp"
 namespace LAGRID {
     FreeCoordBoxGrid::FreeCoordBoxGrid(const Vector_1D& dx, const Vector_1D& dy, const Vector_2D& phi, const Vector_1D& x0, double y0, double cutoff) {
-        auto isInteriorCell = [&](int i, int j) -> bool {
+        auto isInteriorCell = [&](std::size_t i, std::size_t j) -> bool {
             bool edgeIndex = (i == 0 || j == 0 || i == dx.size() - 1 || j == dy.size() - 1);
             return !edgeIndex && (phi[j+1][i] > cutoff && phi[j-1][i] > cutoff && 
                                   phi[j][i+1] > cutoff && phi[j][i-1] > cutoff);
         };
 
         double curr_y = y0; // Y coordinate of bottom edge of the cell row
-        for(int j = 0; j < dy.size(); j++) {
+        for(std::size_t j = 0; j < dy.size(); j++) {
             double curr_x = x0[j]; // X coord of left edge of cell column
-            for(int i = 0; i < dx.size(); i++) {
+            for(std::size_t i = 0; i < dx.size(); i++) {
                 if(phi[j][i] < cutoff) {
                     curr_x += dx[j];
                     continue;
@@ -27,8 +27,8 @@ namespace LAGRID {
     }
 
     FreeCoordBoxGrid::FreeCoordBoxGrid(const Vector_1D& dx, const Vector_1D& dy, const Vector_2D& phi, const Vector_1D& x0, double y0, const vector<vector<int>>& mask) {
-        int nx = phi[0].size();
-        auto isInteriorCell = [&](int i, int j) -> bool {
+        std::size_t nx = phi[0].size();
+        auto isInteriorCell = [&](std::size_t i, std::size_t j) -> bool {
             bool edgeIndex = (i == 0 || j == 0 || i == nx - 1 || j == dy.size() - 1);
             return !edgeIndex && (mask[j+1][i] == 1 && mask[j-1][i] == 1 && 
                                   mask[j][i+1] == 1 && mask[j][i-1] == 1);
@@ -36,9 +36,9 @@ namespace LAGRID {
 
         double curr_y = y0; // Y coordinate of bottom edge of the cell row
 
-        for(int j = 0; j < dy.size(); j++) {
+        for(std::size_t j = 0; j < dy.size(); j++) {
             double curr_x = x0[j]; // X coord of left edge of cell column
-            for(int i = 0; i < nx; i++) {
+            for(std::size_t i = 0; i < nx; i++) {
                 if(mask[j][i] == 0) {
                     curr_x += dx[j];
                     continue;

--- a/Code.v05-00/src/LAGRID/RemappingFunctions.cpp
+++ b/Code.v05-00/src/LAGRID/RemappingFunctions.cpp
@@ -3,7 +3,7 @@ namespace LAGRID {
 
     void twoDGridVariable::addBuffer(double bufLen_left, double bufLen_right, double bufLen_top, double bufLen_bot, double fillValue) {
         int nx_before = xCoords.size();
-        int ny_before = yCoords.size();
+        // int ny_before = yCoords.size();
 
         //Generate coords of buffer areas
         int numRows_topBuffer = std::floor(bufLen_top / dy);
@@ -89,7 +89,7 @@ namespace LAGRID {
             const MassBox& b = boxGrid.boxes[box_idx];
             int startGridIdx_x = std::floor((b.topLeftX - remapping.x0) / remapping.dx);
             int endGridIdx_x = std::floor((b.botRightX - remapping.x0) / remapping.dx);
-            int startGridIdx_y = std::floor((b.topLeftY - remapping.y0) / remapping.dy);
+            // int startGridIdx_y = std::floor((b.topLeftY - remapping.y0) / remapping.dy);
             int endGridIdx_y = std::floor((b.botRightY - remapping.y0) / remapping.dy);
 
             for (int j = endGridIdx_y; j <= endGridIdx_y; j++) {

--- a/Code.v05-00/src/LAGRID/RemappingFunctions.cpp
+++ b/Code.v05-00/src/LAGRID/RemappingFunctions.cpp
@@ -35,7 +35,7 @@ namespace LAGRID {
 
         //rotate right by numRows_botBuffer to get those on the other side.
         std::rotate(phi.rbegin(), phi.rbegin() + numRows_botBuffer, phi.rend());
-        for(int j = 0; j < yCoords.size(); j++) {
+        for(std::size_t j = 0; j < yCoords.size(); j++) {
             phi[j].insert(phi[j].begin(), numCols_leftBuffer, fillValue);
             phi[j].insert(phi[j].end(), numCols_rightBuffer, fillValue);
         }

--- a/Code.v05-00/src/Util/MetFunction.cpp
+++ b/Code.v05-00/src/Util/MetFunction.cpp
@@ -270,7 +270,7 @@ namespace met
 
     } /* End of ComputeLapseRate */
 
-    int nearestNeighbor( const Vector_1D& xq, double x ) {
+    std::size_t nearestNeighbor( const Vector_1D& xq, double x ) {
 
         /* DESCRIPTION: Finds the closest of x in xq, returning the index */
 
@@ -279,7 +279,7 @@ namespace met
          * double x:  desired value */
 
         double diff = std::numeric_limits<double>::max();
-        for(int i = 0; i < xq.size(); i++) {
+        for(std::size_t i = 0; i < xq.size(); i++) {
             double newDiff = std::abs(xq[i] - x);
             if(newDiff >= diff) {
                 return i - 1;
@@ -353,8 +353,8 @@ namespace met
     }
     double linInterpMetData(const Vector_1D& altitude_init, const Vector_1D& metVar_init, double altitude_query){
         // Alt input is increasing
-        int i_Z = nearestNeighbor( altitude_init, altitude_query );
-        int idx_x1;
+        std::size_t i_Z = nearestNeighbor( altitude_init, altitude_query );
+        std::size_t idx_x1;
 
         //Edge cases
         const double epsilon = 1e-3;
@@ -371,7 +371,7 @@ namespace met
         }
         
 
-        int idx_x2 = idx_x1 + 1;
+        std::size_t idx_x2 = idx_x1 + 1;
         if(idx_x1 < 0) { 
             throw std::range_error("Input flight altitude out of range of met. data!"); 
         }
@@ -397,7 +397,7 @@ namespace met
          * YLIM_DOWN: bottom limit of domain */
 
         double satdepth = 0.00E+00;
-        double curdepth = 0.00E+00;
+        // double curdepth = 0.00E+00;
         int iCur = iFlight;
         double RHi_cur, RHi_prev;
 

--- a/Code.v05-00/src/Util/PhysFunction.cpp
+++ b/Code.v05-00/src/Util/PhysFunction.cpp
@@ -712,12 +712,11 @@ namespace physFunc
 
     Vector_2D RHi_Field(const Vector_2D& H2O, const Vector_2D& T, const Vector_1D& P) {
         Vector_2D RHi(H2O.size(), Vector_1D(H2O[0].size(), 0));
-        double pH2O, locP;
+        double pH2O;
         #pragma omp parallel for \
-        private(pH2O, locP)
-        for(int jNy = 0; jNy < H2O.size(); jNy++){
-            locP = P[jNy];
-            for (int iNx = 0; iNx < H2O[0].size(); iNx++){
+        private(pH2O)
+        for(std::size_t jNy = 0; jNy < H2O.size(); jNy++){
+            for (std::size_t iNx = 0; iNx < H2O[0].size(); iNx++){
                 pH2O = physConst::R * T[jNy][iNx] * H2O[jNy][iNx] /(physConst::Na*1e-6);
                 RHi[jNy][iNx] = pH2O / pSat_H2Os(T[jNy][iNx]);
             }

--- a/Code.v05-00/src/Util/VectorUtils.cpp
+++ b/Code.v05-00/src/Util/VectorUtils.cpp
@@ -16,8 +16,8 @@ namespace VectorUtils {
 
     double VecMin2D (const Vector_2D& vec) {
         double min = std::numeric_limits<double>::max();
-        for (int j = 0; j < vec.size(); j++) {
-            for (int i = 0; i < vec[0].size(); i++) {
+        for (std::size_t j = 0; j < vec.size(); j++) {
+            for (std::size_t i = 0; i < vec[0].size(); i++) {
                 if(std::isinf(vec[j][i]) || std::isnan(vec[j][i])) throw std::out_of_range("in VectorUtils::VecMin2D: inf or nan found in vector");
                 if(vec[j][i] < min) min = vec[j][i];
             }
@@ -27,8 +27,8 @@ namespace VectorUtils {
 
     double VecMax2D (const Vector_2D& vec) {
         double max = std::numeric_limits<double>::min();
-        for (int j = 0; j < vec.size(); j++) {
-            for (int i = 0; i < vec[0].size(); i++) {
+        for (std::size_t j = 0; j < vec.size(); j++) {
+            for (std::size_t i = 0; i < vec[0].size(); i++) {
                 if(std::isinf(vec[j][i]) || std::isnan(vec[j][i])) throw std::out_of_range("in VectorUtils::VecMax2D: inf or nan found in vector");
                 if(vec[j][i] > max) max = vec[j][i];
             }
@@ -41,9 +41,9 @@ namespace VectorUtils {
 
         if(axis == 0) {
             axis_max = Vector_1D(vec.size());
-            for (int j = 0; j < vec.size(); j++) {
+            for (std::size_t j = 0; j < vec.size(); j++) {
                 double rowMax = std::numeric_limits<double>::min();
-                for (int i = 0; i < vec[0].size(); i++) {
+                for (std::size_t i = 0; i < vec[0].size(); i++) {
                     if(std::isinf(vec[j][i]) || std::isnan(vec[j][i])) throw std::out_of_range("in VectorUtils::VecMax2D: inf or nan found in vector");
                     if(vec[j][i] > rowMax) rowMax = vec[j][i];
                 }
@@ -52,9 +52,9 @@ namespace VectorUtils {
         }
         else {
             axis_max = Vector_1D(vec[0].size());
-            for (int i = 0; i < vec[0].size(); i++) {
+            for (std::size_t i = 0; i < vec[0].size(); i++) {
                 double colMax = std::numeric_limits<double>::min();
-                for (int j = 0; j < vec.size(); j++) {
+                for (std::size_t j = 0; j < vec.size(); j++) {
                     if(std::isinf(vec[j][i]) || std::isnan(vec[j][i])) throw std::out_of_range("in VectorUtils::VecMax2D: inf or nan found in vector");
                     if(vec[j][i] > colMax) colMax = vec[j][i];
                 }
@@ -67,8 +67,8 @@ namespace VectorUtils {
 
     double Vec2DSum (const Vector_2D& vec) {
         double sum = 0;
-        for (int j = 0; j < vec.size(); j++) {
-            for (int i = 0; i < vec[0].size(); i++) {
+        for (std::size_t j = 0; j < vec.size(); j++) {
+            for (std::size_t i = 0; i < vec[0].size(); i++) {
                 sum += vec[j][i];
             }
         }
@@ -78,8 +78,8 @@ namespace VectorUtils {
     std::pair<vector<vector<int>>, int> Vec2DMask (const Vector_2D& vec, std::function<bool (double)> maskFunc) {
         vector<vector<int>> mask(vec.size(), vector<int>(vec[0].size()));
         int nonMaskedElems = 0;
-        for (int j = 0; j < vec.size(); j++) {
-            for (int i = 0; i < vec[0].size(); i++) {
+        for (std::size_t j = 0; j < vec.size(); j++) {
+            for (std::size_t i = 0; i < vec[0].size(); i++) {
                 mask[j][i] = maskFunc(vec[j][i]);
                 if(mask[j][i]) {
                     nonMaskedElems++;
@@ -99,8 +99,8 @@ namespace VectorUtils {
         double maxX = std::numeric_limits<double>::lowest();
         double maxY = std::numeric_limits<double>::lowest();
 
-        for (int j = 0; j < vec.size(); j++) {
-            for (int i = 0; i < vec[0].size(); i++) {
+        for (std::size_t j = 0; j < vec.size(); j++) {
+            for (std::size_t i = 0; i < vec[0].size(); i++) {
                 mask[j][i] = maskFunc(vec[j][i]);
                 if(mask[j][i]){
                     nonMaskedElems++;
@@ -128,8 +128,8 @@ namespace VectorUtils {
         Vector_2D result(vec1.size(), Vector_1D(vec1[0].size()));
 
         #pragma omp parallel for
-        for(int j = 0; j < vec1.size(); j++) {
-            for(int i = 0; i < vec1[0].size(); i++) {
+        for(std::size_t j = 0; j < vec1.size(); j++) {
+            for(std::size_t i = 0; i < vec1[0].size(); i++) {
                 result[j][i] = transformFunc(vec1[j][i], vec2[j][i]);
             }
         }

--- a/Code.v05-00/src/YamlInputReader/YamlInputReader.cpp
+++ b/Code.v05-00/src/YamlInputReader/YamlInputReader.cpp
@@ -314,7 +314,7 @@ namespace YamlInputReader{
         }
     }
 
-    vector<std::unordered_map<string, double>> generateCasesHelper(vector<std::unordered_map<string, double>>& allCases, const vector<std::pair<string, Vector_1D>>& params, const int row){
+    vector<std::unordered_map<string, double>> generateCasesHelper(vector<std::unordered_map<string, double>>& allCases, const vector<std::pair<string, Vector_1D>>& params, const std::size_t row){
         if(row ==  params.size()){
             return allCases;
         }

--- a/Code.v05-00/src/YamlInputReader/YamlInputReader.cpp
+++ b/Code.v05-00/src/YamlInputReader/YamlInputReader.cpp
@@ -94,7 +94,10 @@ namespace YamlInputReader{
         input.SIMULATION_MCRUNS =  parseIntString(paramSweepSubmenu["Num Monte Carlo runs (int)"].as<string>(), "Num Monte Carlo runs (int)");
 
         YAML::Node outputSubmenu = simNode["OUTPUT SUBMENU"];
-        input.SIMULATION_OUTPUT_FOLDER = parseFileSystemPath(outputSubmenu["Output folder (string)"].as<string>());
+        std::string outputFolder =  parseFileSystemPath(outputSubmenu["Output folder (string)"].as<string>());
+        // Ensure path to save directory is terminated by "/"
+        if ( outputFolder.back() != '/' ) {outputFolder = outputFolder + "/";}
+        input.SIMULATION_OUTPUT_FOLDER = outputFolder;
         input.SIMULATION_OVERWRITE = parseBoolString(outputSubmenu["Overwrite if folder exists (T/F)"].as<string>(), "Overwrite if folder exists (T/F)");
         input.SIMULATION_THREADED_FFT = parseBoolString(simNode["Use threaded FFT (T/F)"].as<string>(), "Use threaded FFT (T/F)");
 

--- a/Code.v05-00/tests/test_LAGRID.cpp
+++ b/Code.v05-00/tests/test_LAGRID.cpp
@@ -72,8 +72,8 @@ TEST_CASE("FreeCoordBoxGrid and Remapping") {
         REQUIRE(twoDGrid.xCoords[10] == 20);
 
         double mass_after = 0;
-        for (int j = 0; j < twoDGrid.phi.size(); j++){
-            for (int i = 0; i < twoDGrid.phi[0].size(); i++) {
+        for (std::size_t j = 0; j < twoDGrid.phi.size(); j++){
+            for (std::size_t i = 0; i < twoDGrid.phi[0].size(); i++) {
                 mass_after += twoDGrid.phi[j][i] * twoDGrid.dx * twoDGrid.dy;
             }
         }
@@ -101,8 +101,8 @@ TEST_CASE("FreeCoordBoxGrid and Remapping") {
         REQUIRE(twoDGrid.phi.size() == 12);
         REQUIRE(twoDGrid.phi[0].size() == 19);
         double mass = 0;
-        for (int j = 0; j < twoDGrid.phi.size(); j++){
-            for (int i = 0; i < twoDGrid.phi[0].size(); i++) {
+        for (std::size_t j = 0; j < twoDGrid.phi.size(); j++){
+            for (std::size_t i = 0; i < twoDGrid.phi[0].size(); i++) {
                 mass += twoDGrid.phi[j][i] * twoDGrid.dx * twoDGrid.dy;
             }
         }

--- a/Code.v05-00/tests/test_adv_diff_solver.cpp
+++ b/Code.v05-00/tests/test_adv_diff_solver.cpp
@@ -88,8 +88,15 @@ namespace FVM_ANDS{
     std::tuple<double, double, double> interiorMax(const Eigen::VectorXd& vec, double xmin, double xmax, double ymin, double ymax, int nx, int ny){
         double dx = (xmax - xmin) / nx;
         double dy = (ymax - ymin) / ny;
-        double max = std::numeric_limits<double>::min();
-        double maxx, maxy;
+
+        /* Initialize maximum to be the first value in the vector
+        Avoids compiler complaining about edge case where all
+        values are equal to std::numeric_limits::min() which leaves
+        variables uninitialized */
+        double max = vec(0);
+        double maxx = dx * 0.5;
+        double maxy = dy * 0.5;
+
         for(int i = 0; i < nx; i++){
             for(int j = 0; j < ny; j++){
                 double x = dx * (0.5 + i);
@@ -106,8 +113,15 @@ namespace FVM_ANDS{
     std::tuple<double, double, double> interiorMin(const Eigen::VectorXd& vec, double xmin, double xmax, double ymin, double ymax, int nx, int ny){
         double dx = (xmax - xmin) / nx;
         double dy = (ymax - ymin) / ny;
-        double min = std::numeric_limits<double>::max();
-        double minx, miny;
+
+        /* Initialize minimum to be the first value in the vector
+        Avoids compiler complaining about edge case where all
+        values are equal to std::numeric_limits::max() which leaves
+        variables uninitialized */
+        double min = vec(0);
+        double minx = dx * 0.5;
+        double miny = dy * 0.5;
+
         for(int i = 0; i < nx; i++){
             for(int j = 0; j < ny; j++){
                 double x = dx * (0.5 + i);
@@ -284,8 +298,8 @@ namespace FVM_ANDS{
         
         double u = 0, v = 0, shear = 0, Dh = 1.0, Dv = 1.0, xlim_left = 0.1, xlim_right = 0.8, ylim_bot = 0.2, ylim_top = 0.9;
         int nx = 100, ny = 100;
-        double dx = 1.0/nx;
-        double dy = 1.0/ny;
+        // double dx = 1.0/nx;
+        // double dy = 1.0/ny;
         //double dt = 0.24 * std::min( (dx*dx) / (2*Dh) , (dy*dy) / (2*Dv));
         double dt = 0.1;
         std::cout << "dt: " << dt << std::endl;
@@ -465,11 +479,12 @@ namespace FVM_ANDS{
         cout << "Soln Maximum: " << solver.phi().maxCoeff() << "\n";
         cout << "Soln Interior Minimum: " << solver.phi()(Eigen::seq(0,nx*ny-1)).minCoeff() << "\n";
 
-        double t = 0, t_max = 1;
+        // double t;
+        double t_max = 1;
         int n_timesteps = t_max/dt;
         double max, maxx, maxy, min, minx, miny;
         for(int i = 0; i < n_timesteps; i++){
-            t = dt*(i + 1); //implicit method
+            // t = dt*(i + 1); //implicit method
             cout << "solving" << endl;
             Eigen::VectorXd soln = solver.solve();
             auto interior_idxs = Eigen::seq(0, nx*ny - 1);

--- a/Code.v05-00/tests/test_aerosol.cpp
+++ b/Code.v05-00/tests/test_aerosol.cpp
@@ -18,7 +18,7 @@ TEST_CASE ("Aerosol", "[single-file]" ) {
     int nBins = 100;
     double r_min = 1e-8;
     double r_max = 10e-6;
-    double bin_size = (r_max - r_min)/nBins;
+    // double bin_size = (r_max - r_min)/nBins;
 
     Vector_1D bin_centers(nBins);
     Vector_1D bin_edges(nBins+1);
@@ -153,12 +153,12 @@ TEST_CASE ("Aerosol", "[single-file]" ) {
     SECTION("Coagulation, Smoluchowski monodisperse analytical solution") {
         // Test against figure 15.2 from Jacobson (2005)
         double T = 298.;
-        double p = 101325.;
-        double rho = 1.0e3;
+        // double p = 101325.;
+        // double rho = 1.0e3;
         double n0 = 10.e6; 
         double r0 = 3.0e-9; 
         double V0 = (4/3.0)*physConst::PI*pow(r0, 3);
-        double h = 12.0 * 3600;
+        // double h = 12.0 * 3600;
         double kb = 1.38064852e-23;
         double eta = 1.8235e-5;
         double beta = 1.0e6 * 8*kb*T/(3*eta);

--- a/Code.v05-00/tests/test_buildkernel.cpp
+++ b/Code.v05-00/tests/test_buildkernel.cpp
@@ -47,7 +47,7 @@ TEST_CASE("Build kernel", "[single-file]") {
         bin_centers2[0] = 0.5*0.002e-6;
         double rho_1 =  1.0e3;
         double rho_2 = 1.0e3;
-        double bin_R = 0.5*0.002e-6;
+        // double bin_R = 0.5*0.002e-6;
 
         Vector_2D kernel = buildBrownianKernel(T, p, bin_centers1, rho_1, bin_centers2, rho_2);
 

--- a/Code.v05-00/tests/test_metfunction.cpp
+++ b/Code.v05-00/tests/test_metfunction.cpp
@@ -104,7 +104,7 @@ TEST_CASE( "MetFunction", "[single-file]" ) {
 		try{
 			satdepth_calc(RHw3, T, alt, 6, 1500);
 		}
-		catch(std::out_of_range e){
+		catch(std::out_of_range &e){
 			std::string error = e.what();
 			REQUIRE(error == "In met::satdepth_calc: No end of ice supersaturated layer found.");
 		}

--- a/Code.v05-00/tests/test_yamlreader.cpp
+++ b/Code.v05-00/tests/test_yamlreader.cpp
@@ -2,6 +2,7 @@
 #include <YamlInputReader/YamlInputReader.hpp>
 #include <Core/Input.hpp>
 #include <iostream>
+#include "APCEMM.h"
 using namespace YamlInputReader;
 using std::cout;
 using std::endl;
@@ -44,7 +45,7 @@ TEST_CASE("YamlInputReader Helper Functions"){
         try{
             tokens = split(" ", "");
         }
-        catch(std::invalid_argument e){
+        catch(std::invalid_argument &e){
             err = string(e.what());
         }
         REQUIRE(err.find("In YamlInputReader::split: Delimiter length cannot be zero") == 0);
@@ -61,7 +62,7 @@ TEST_CASE("YamlInputReader Helper Functions"){
             try{
                 strToDouble("asdf");
             }
-            catch (std::invalid_argument e){
+            catch (std::invalid_argument &e){
                 error = e.what();
             }
             REQUIRE (error.find("Something went wrong with processing a number") == 0);
@@ -69,7 +70,7 @@ TEST_CASE("YamlInputReader Helper Functions"){
             try{
                 strToDouble("10 2e3");
             }
-            catch (std::invalid_argument e){
+            catch (std::invalid_argument &e){
                 error = e.what();
             }
             REQUIRE (error.find("Something went wrong with processing a number") == 0);
@@ -77,7 +78,7 @@ TEST_CASE("YamlInputReader Helper Functions"){
             try{
                 strToDouble("1e3e3");
             }
-            catch (std::invalid_argument e){
+            catch (std::invalid_argument &e){
                 error = e.what();
             }
             REQUIRE (error.find("Something went wrong with processing a number") == 0);
@@ -85,7 +86,7 @@ TEST_CASE("YamlInputReader Helper Functions"){
             try{
                 strToDouble("2e-4.");
             }
-            catch (std::invalid_argument e){
+            catch (std::invalid_argument &e){
                 error = e.what();
             }
             REQUIRE (error.find("Something went wrong with processing a number") == 0);
@@ -93,7 +94,7 @@ TEST_CASE("YamlInputReader Helper Functions"){
             try{
                 strToDouble("10e3.3");
             }
-            catch (std::invalid_argument e){
+            catch (std::invalid_argument &e){
                 error = e.what();
             }
             REQUIRE (error.find("Something went wrong with processing a number") == 0);
@@ -113,7 +114,7 @@ TEST_CASE("YamlInputReader Helper Functions"){
         try{
             parseBoolString("");
         }
-        catch(std::invalid_argument e){
+        catch(std::invalid_argument &e){
             err = e.what();
         }
         REQUIRE(err.find("Unable to read boolean value") == 0);
@@ -150,35 +151,35 @@ TEST_CASE("YamlInputReader Helper Functions"){
         try{
             vec = parseParamSweepInput("1:2:3:4", "", true, 10);
         }
-        catch (std::invalid_argument e){
+        catch (std::invalid_argument &e){
             err = e.what();
         }
         REQUIRE(err.find("Monte Carlo Simulation requires") == 0);
         try{
             vec = parseParamSweepInput("1:2");
         }
-        catch (std::invalid_argument e){
+        catch (std::invalid_argument &e){
             err = e.what();
         }
         REQUIRE(err.find("Parameter sweep step input requires") == 0);
         try{
             vec = parseParamSweepInput("1 asdf ed 3");
         }
-        catch (std::invalid_argument e){
+        catch (std::invalid_argument &e){
             err = e.what();
         }
         REQUIRE(err.find("Something went wrong with processing a number") == 0);
         try{
             vec = parseParamSweepInput("10:10:20 0");
         }
-        catch(std::invalid_argument e){
+        catch(std::invalid_argument &e){
             if(string(e.what()).find("Something went wrong with processing a number") == 0) err = "stod fail 1";
         }
         REQUIRE(err == "stod fail 1");
         try{
             vec = parseParamSweepInput("10:10:20..0");
         }
-        catch(std::invalid_argument e){
+        catch(std::invalid_argument &e){
             if(string(e.what()).find("Something went wrong with processing a number") == 0) err = "stod fail 2";
         }
         REQUIRE(err == "stod fail 2");
@@ -194,10 +195,13 @@ TEST_CASE("Read Yaml File"){
         try{
             readSimMenu(input, data["SIMULATION MENU"]);
         }
-        catch (std::invalid_argument e){
+        catch (std::invalid_argument &e){
             err = e.what();
         }
-        REQUIRE(input.SIMULATION_OMP_NUM_THREADS == 8);
+        // If in DEBUG, SIMULATION_OMP_NUM_THREADS is set to 1 which fails the test
+        #ifndef DEBUG
+            REQUIRE(input.SIMULATION_OMP_NUM_THREADS == 8);
+        #endif
         REQUIRE(input.SIMULATION_PARAMETER_SWEEP == true);
         REQUIRE(input.SIMULATION_MONTECARLO == true);
         REQUIRE(input.SIMULATION_MCRUNS == 2);
@@ -297,7 +301,7 @@ TEST_CASE("Read Yaml File"){
         try{
             readMetMenu(input, data["METEOROLOGY MENU"]);
         }
-        catch(std::invalid_argument e){
+        catch(std::invalid_argument &e){
             error = e.what();
         }
     

--- a/Code.v05-00/vcpkg.json
+++ b/Code.v05-00/vcpkg.json
@@ -6,6 +6,7 @@
     "boost-range",
     "catch2",
     "eigen3",
+    "fmt",
     "fftw3",
     "netcdf-cxx4",
     "yaml-cpp"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ See the [Dockerfile](.devcontainer/Dockerfile.apcemm) in the .devcontainer direc
 
 ## APCEMM: Installation instructions
 
-APCEMM can be built using CMake. Previously, the dependency structure and compile instructions were specified using manually generated Makefiles. CMake generates these Makefiles automatically, and should lead to a more pleasant software build experience. Dependencies on external libraries are managed using the [vcpkg](https://vcpkg.io/en/) tool, which is installed as a Git submodule. (This means that you just need to run the `git submodule update` command below to set it up.)
+APCEMM can be built using CMake and requires GCC >= 11.2. Previously, the dependency structure and compile instructions were specified using manually generated Makefiles. CMake generates these Makefiles automatically, and should lead to a more pleasant software build experience. Dependencies on external libraries are managed using the [vcpkg](https://vcpkg.io/en/) tool, which is installed as a Git submodule. (This means that you just need to run the `git submodule update` command below to set it up.)
 
 CMake will generate a single executable `APCEMM` that can receive an input file `input.yaml`. To compile this executable, you can call CMake as follows:
 


### PR DESCRIPTION
Fixes all compiler warnings with -Wall. Tested with  gcc 14.1
Compiling with ```-DDEBUG=ON```, results are bitwise reproducible with commit _fa4fded_.

Some warnings should have affected the result but did not because of either not passing a threshold or being cancelled out by another bug.

Added ```-fopenmp``` to compile flags as gcc was warning that the OMP #pragma were not defined and ignored otherwise. This seems strange because previous versions of APCEMM did seem to be multithreaded. I don't know if anyone has insights into this.