### PR TITLE
Disable vertical velocities and implement improved mask definition

### DIFF
--- a/Code.v05-00/include/Core/LAGRIDPlumeModel.hpp
+++ b/Code.v05-00/include/Core/LAGRIDPlumeModel.hpp
@@ -53,6 +53,7 @@ class LAGRIDPlumeModel {
         Vector_1D xCoords_;
         Vector_1D xEdges_;
         Vector_2D H2O_;
+        Vector_2D Contrail_;
         Vector_1D vFall_;
         double initNumParts_;
         double simTime_h_;
@@ -84,13 +85,20 @@ class LAGRIDPlumeModel {
             return VectorUtils::Vec2DMask(diffH2O, xEdges_, yEdges_, maskFunc);
         }
 
+        inline MaskType ContrailMask(double minVal=1.0e-2) {
+            auto maskFunc = [minVal](double val) {
+                return val > minVal;
+            };
+            return VectorUtils::Vec2DMask(Contrail_, xEdges_, yEdges_, maskFunc);
+        }
+
         void createOutputDirectories();
         void initializeGrid();
         void saveTSAerosol();
         void initH2O();
         void updateDiffVecs();
         void runTransport(double timestep);
-        void remapAllVars(double remapTimestep);
+        void remapAllVars(double remapTimestep, const std::vector<std::vector<int>>& mask, const VectorUtils::MaskInfo& maskInfo);
         void trimH2OBoundary();
         std::pair<LAGRID::twoDGridVariable,LAGRID::twoDGridVariable> remapVariable(const VectorUtils::MaskInfo& maskInfo, const BufferInfo& buffers, const Vector_2D& phi, const std::vector<std::vector<int>>& mask);
         double totalAirMass();

--- a/Code.v05-00/include/Core/LAGRIDPlumeModel.hpp
+++ b/Code.v05-00/include/Core/LAGRIDPlumeModel.hpp
@@ -69,6 +69,21 @@ class LAGRIDPlumeModel {
             return VectorUtils::Vec2DMask(iceTotalNum, xEdges_, yEdges_, iceNumMaskFunc);
         }
 
+        inline MaskType H2OMask() {
+            Vector_2D metH2O = met_.H2O_field();
+            Vector_2D diffH2O = Vector_2D(yCoords_.size(), Vector_1D(xCoords_.size()));
+            for (std::size_t j = 0; j < yCoords_.size(); j++) {
+                for (std::size_t i = 0; i < xCoords_.size(); i++) {
+                    diffH2O[j][i] = std::abs(H2O_[j][i] - metH2O[j][i]);
+                }
+            }
+            double maxDiff = 1.0e6;
+            auto maskFunc = [maxDiff](double val) {
+                return val > maxDiff;
+            };
+            return VectorUtils::Vec2DMask(diffH2O, xEdges_, yEdges_, maskFunc);
+        }
+
         void createOutputDirectories();
         void initializeGrid();
         void saveTSAerosol();

--- a/Code.v05-00/src/Core/LAGRIDPlumeModel.cpp
+++ b/Code.v05-00/src/Core/LAGRIDPlumeModel.cpp
@@ -415,9 +415,12 @@ std::pair<LAGRID::twoDGridVariable,LAGRID::twoDGridVariable> LAGRIDPlumeModel::r
 void LAGRIDPlumeModel::remapAllVars(double remapTimestep) {
     //Generate free box grid from met post-advection
     Vector_2D iceTotalNum = iceAerosol_.TotalNumber();
-    auto numberMask = iceNumberMask();
-    auto& mask = numberMask.first;
-    auto& maskInfo = numberMask.second;
+    //auto contrailMask = iceNumberMask();
+    // WARNING: H2O approach may not work well with temperature
+    // fluctuation field active
+    auto contrailMask = H2OMask();
+    auto& mask = contrailMask.first;
+    auto& maskInfo = contrailMask.second;
 
     Vector_3D& pdfRef = iceAerosol_.getPDF_nonConstRef();
     Vector_3D volume = iceAerosol_.Volume();

--- a/Code.v05-00/src/Core/Meteorology.cpp
+++ b/Code.v05-00/src/Core/Meteorology.cpp
@@ -630,6 +630,12 @@ void Meteorology::vertAdvectAltPress(double dt) {
 
     double omega = dp_dz * w_local;
 
+    // SDE 2024-08-12: Disabled temporarily while pressure velocity issues are fixed
+    if (std::abs(omega) > 1.0e-10 ){
+        std::cout << " -- WARNING: PRESSURE VELOCITIES CURRENTLY DISABLED -- " << std::endl;
+    }
+    return;
+
     /* Update edges instead of centers (altitude_, pressure_) because altitude-pressure relationship
        is nonlinear. Therefore, the relative position of the center will move hwen advecting at some
        constant pressure velocity. If we then assume a constant dx without moving the center, we will

--- a/Code.v05-00/src/LAGRID/RemappingFunctions.cpp
+++ b/Code.v05-00/src/LAGRID/RemappingFunctions.cpp
@@ -123,12 +123,25 @@ namespace LAGRID {
         Vector_2D phi_new(ny, Vector_1D(nx));
         Vector_1D dx_new(ny);
         Vector_1D x0_new(ny);
+        /*
         for(int j = 0; j < ny; j++) {
             dx_new[j] = dx_old * dy_new[j] / dy_old;
             x0_new[j] = x0_old + nx * (dx_old - dx_new[j]) / 2;
             double cellAreaRatio = dy_new[j] * dy_new[j] / (dy_old * dy_old);
             for(int i = 0; i < nx; i++) {
                 phi_new[j][i] = phi_old[j][i] / cellAreaRatio;
+            }
+        }
+        */
+        // SDE 2024-08-12: Kludge - above is causing significant and cumulative noise
+        // due to errors propagating from the met_.Update() calculation, even when
+        // pressure velocity is zero
+        for(int j = 0; j < ny; j++) {
+            dx_new[j] = dx_old;
+            x0_new[j] = x0_old;
+            double cellAreaRatio = dy_new[j] * dy_new[j] / (dy_old * dy_old);
+            for(int i = 0; i < nx; i++) {
+                phi_new[j][i] = phi_old[j][i];
             }
         }
         return FreeCoordBoxGrid(dx_new, dy_new, phi_new, x0_new, y0_new, mask);


### PR DESCRIPTION
Vertical velocities are temporarily disabled, due to issues #17 and #26 which revealed that the vertical velocity handling was introducing unexpected artifacts. The mask used to propagate water and ice from time step to time step has also been replaced. Previously, the ice particle number was used, with locations retained if it exceeded 1.0e-5 times the highest value remaining in the simulation. This had two downsides. First, if the ice particle density became somewhat uniform, then increasingly large areas would be preserved simply because the peak number was falling. Second, regions which were previously dehydrated but which crystals were not currently present in would be marked as not containing contrail, meaning that the effect of earlier passage of ice would not necessarily be preserved. Both issues are resolved by the use of an inert tracer to represent contrail influence. The inert tracer is set to 1.0 within the plume at initiation of the 2D simulation, and then allowed to advect and diffuse as a gas. At each time step it is then set to its current value plus the local number concentration in particles per meter cubed, capped at a value of 1.0. Any location which has a value of at least 0.2 is then retained when transferring data to the next time step, while all other locations are overwritten with zero ice and with water from the background meteorology at that time and altitude.

This edit can result in longer run times as ice can now persist in a just-saturated layer at low altitude. Users may wish to experiment with changing the thresholds for triggering the end of the simulation if they want to reduce run time.