### PR TITLE
Fix dockerfile requirements for APCEMM compiling

### DIFF
--- a/.devcontainer/Dockerfile.apcemm
+++ b/.devcontainer/Dockerfile.apcemm
@@ -20,7 +20,7 @@ RUN apt-get update \
   autoconf \
   automake \
   libtool \
-  curl zip unzip tar
+  zip unzip tar
 
 RUN apt-get clean \
   && rm -rf /var/lib/apt/lists/* \

--- a/.devcontainer/Dockerfile.apcemm
+++ b/.devcontainer/Dockerfile.apcemm
@@ -19,7 +19,8 @@ RUN apt-get update \
   zsh \
   autoconf \
   automake \
-  libtool 
+  libtool \
+  curl zip unzip tar
 
 RUN apt-get clean \
   && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
As it currently stands, attempting to compile APCEMM from a Docker image in Windows VSCode results in the following error upon running the `cmake ../Code.v05-00` command:

>Submodule 'Code.v05-00/submodules/vcpkg' (https://github.com/Microsoft/vcpkg.git) registered for path '../../Code.v05-00/submodules/vcpkg'
>Cloning into '/home/APCEMM/Code.v05-00/submodules/vcpkg'...
>Submodule path '../../Code.v05-00/submodules/vcpkg': checked out '2a6371b01420d8820d158b4707e79931feba27aa'
>-- Bootstrapping vcpkg before install
>-- Bootstrapping vcpkg before install - failed
>CMake Error at submodules/vcpkg/scripts/buildsystems/vcpkg.cmake:899 (message):
>  vcpkg install failed.  See logs for more information:
>  /home/APCEMM/build/vcpkg-bootstrap.log
>Call Stack (most recent call first):
>  /opt/cmake-3.24.1/share/cmake-3.24/Modules/CMakeDetermineSystem.cmake:124 (include)
>  CMakeLists.txt:6 (project)
>
>
>CMake Error: CMake was unable to find a build program corresponding to "Unix Makefiles".  CMAKE_MAKE_PROGRAM is not set.  You probably need to select a different build tool.
>CMake Error: CMAKE_C_COMPILER not set, after EnableLanguage
>CMake Error: CMAKE_CXX_COMPILER not set, after EnableLanguage
>-- Configuring incomplete, errors occurred!

I managed to solve this issue by running the following command in the terminal: `sudo apt install curl zip unzip tar`.

This PR makes the docker environment have the `curl zip unzip tar` packages installed by default, thereby enabling compilation.