### PR TITLE
Make the examples consistent with the compilation

### DIFF
--- a/examples/Example1_EPM/run_example1.sh
+++ b/examples/Example1_EPM/run_example1.sh
@@ -1,5 +1,10 @@
-cd ../../Code.v05-00/
-cmake . && cmake --build . || exit 1
-cd ../examples/Example1_EPM
+# # Uncomment the following lines to compile APCEMM
+# git submodule update --init --recursive
+# mkdir ../../build
+# cd ../../build/
+# cmake ../Code.v05-00/ && cmake --build . || exit 1
+# cd ../examples/Example1_EPM
+
+# Run Example 1
 export APCEMM_runDir="."
-./../../Code.v05-00/APCEMM input.yaml
+./../../build/APCEMM input.yaml

--- a/examples/Example2_Impose_Depth/run_example2.sh
+++ b/examples/Example2_Impose_Depth/run_example2.sh
@@ -1,5 +1,10 @@
-cd ../../Code.v05-00/
-cmake . && cmake --build . || exit 1
-cd ../examples/Example2_Impose_Depth
+# # Uncomment the following lines to compile APCEMM
+# git submodule update --init --recursive
+# mkdir ../../build
+# cd ../../build/
+# cmake ../Code.v05-00 && cmake --build . || exit 1
+# cd ../examples/Example2_Impose_Depth
+
+# Run Example 2
 export APCEMM_runDir="."
-./../../Code.v05-00/APCEMM input.yaml
+./../../build/APCEMM input.yaml

--- a/examples/Example3_met_input/run_example3.sh
+++ b/examples/Example3_met_input/run_example3.sh
@@ -1,5 +1,10 @@
-cd ../../Code.v05-00/
-cmake . && cmake --build . || exit 1
-cd ../examples/Example3_met_input
+# # Uncomment the following lines to compile APCEMM
+# git submodule update --init --recursive
+# mkdir ../../build
+# cd ../../build/
+# cmake ../Code.v05-00 && cmake --build . || exit 1
+# cd ../examples/Example3_met_input
+
+# Run Example 3
 export APCEMM_runDir="."
-./../../Code.v05-00/APCEMM input.yaml
+./../../build/APCEMM input.yaml


### PR DESCRIPTION
As it stands, if you follow the standard compilation instructions in the README, the `run_exampleX.sh` scripts do not work because of the following:

- APCEMM compilation is re-attempted by default. This can interfere with someone's compiled code.
- If compilation is wanted, attempting compilation through this script does not update the submodules, so it will likely fail.
- The build location does not match that from README.md, so if someone already compiled APCEMM, the running command will not work.

This PR fixes the above issues in the scripts in the examples.