### PR TITLE
Missing crypto libraries caused build failures on Imperial HPC

### DIFF
--- a/Code.v05-00/CMakeLists.txt
+++ b/Code.v05-00/CMakeLists.txt
@@ -77,6 +77,8 @@ target_link_libraries(${PROJECT_NAME} PRIVATE yaml-cpp::yaml-cpp)
 find_package(OpenMP REQUIRED)
 target_link_libraries(${PROJECT_NAME} PRIVATE OpenMP::OpenMP_CXX)
 
+find_package(OpenSSL REQUIRED)
+target_link_libraries(${PROJECT_NAME} PRIVATE OpenSSL::Crypto OpenSSL::SSL crypto ssl)
 
 # This ensures the header files of the necessary libraries are included
 # SYSTEM flag silences the compiler warnings from external dependencies 

--- a/Code.v05-00/tests/CMakeLists.txt
+++ b/Code.v05-00/tests/CMakeLists.txt
@@ -20,7 +20,7 @@ target_link_libraries(unittest  Catch2::Catch2WithMain Util AIM EPM YamlInputRea
 catch_discover_tests(unittest)
 
 add_executable(test_solver test_adv_diff_solver.cpp)
-target_link_libraries(test_solver  Catch2::Catch2WithMain FVM_ANDS Core)
+target_link_libraries(test_solver  Catch2::Catch2WithMain FVM_ANDS Core crypto ssl)
 catch_discover_tests(test_solver)
 
 add_executable(test_LAGRID test_LAGRID.cpp)


### PR DESCRIPTION
Two libraries which are used under the hood by cURL (needed for netCDF) were not explicitly requested during the build process. This resulted in build failure on the new CX3 Phase 2 system at Imperial. The libraries (OpenSSL's Crypto and SSL libraries) are now requested and linked as needed.