### PR TITLE
Fixed two bugs and increased debug info

### DIFF
--- a/Code.v05-00/CMakeLists.txt
+++ b/Code.v05-00/CMakeLists.txt
@@ -13,7 +13,7 @@ option(BUILD_TEST ON)
 
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")	
     include(CheckCXXCompilerFlag)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -gdwarf-2 -gstrict-dwarf -O0 -Wall -Wextra -Wconversion")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O0 -Wall -Wextra -Wconversion")
     #add_compile_options(-fno-omit-frame-pointer -fsanitize=bounds -fsanitize=address -fsanitize=undefined)
     #add_link_options(-fsanitize=bounds -fsanitize=address -fsanitize=undefined)
     add_compile_options(-fno-omit-frame-pointer -fsanitize=bounds -fsanitize=undefined)

--- a/Code.v05-00/src/Core/Meteorology.cpp
+++ b/Code.v05-00/src/Core/Meteorology.cpp
@@ -119,7 +119,10 @@ void Meteorology::estimateSimulationGridPressures(){
     for (int i = 0; i < altitudeDim_; i++) {
         zBase = zCeil;
         zCeil = altitudeInit_[i];
-        while (zNext > zCeil){
+        // Skip the rest of the loop if we haven't yet hit overlap between the
+        // meteorological data (defined on altitude[Edges]Init_) and the sim
+        // grid (defined on altitude[Edges]_)
+        if (zNext > zCeil){
             continue;
         }
         pressureBase = pressureCeil;
@@ -317,7 +320,7 @@ void Meteorology::estimateMetDataAltitudes() {
     const double constFactor = physConst::R_Air / physConst::g;
     // Calculate lapse rate (K/m) between each point
     // Indexing is a bit tricky: 0 is below the first point, last is above the last point
-    lapseInit_.resize(altitudeDim_+1);
+    lapseInit_.resize(altitudeDim_+2);
     altitudeEdgesInit_.resize(altitudeDim_+1);
     pressureEdgesInit_.resize(altitudeDim_+1);
     for (int i = 0; i < altitudeDim_ - 1; i++) {


### PR DESCRIPTION
Two bugs were identified and fixed. First, a loop over altitudes could be entered in a way which would never terminate; it's not actually clear why this was not always happening. Second, a variable was being allocated too little memory by one (lapseInit_), resulting in memory corruption. The debugger compile flags used when -DCMAKE_BUILD_TYPE=Debug is selected have also been pared down (removing -gdwarf-2 and gstrict-dwarf) so that more advanced debugging can be performed.