### PR TITLE
Make the met script compatible with APCEMM 1.2

### DIFF
--- a/scripts/simple_met_input/main.py
+++ b/scripts/simple_met_input/main.py
@@ -5,25 +5,25 @@ import matplotlib.pyplot as plt
 
 if __name__ == "__main__":
     met = make_idealised_met(
-        centre_altitude_m = 10000, # m
-        moist_depth_m = 1000, # m
-        RHi_background_PC = 40, # m
-        RHi_peak_PC = 140, # %
-        grad_RHi_PC_per_m = None, # % RHi / m; None indicates a rectangular moist region
-        alt_resolution_m = 100, # m
-        upper_alt_m = 11001, # m
-        shear_over_s = 2e-3, # 1/s
-        T_offset_K = 0, # K
-        filename_prefix = "example"
+        centre_altitude_m=10000,  # m
+        moist_depth_m=1000,  # m
+        RHi_background_PC=40,  # m
+        RHi_peak_PC=140,  # %
+        grad_RHi_PC_per_m=None,  # % RHi / m; None indicates a rectangular moist region
+        alt_resolution_m=100,  # m
+        upper_alt_m=11001,  # m
+        shear_over_s=2e-3,  # 1/s
+        T_offset_K=0,  # K
+        filename_prefix="example",
     )
 
     RHi_PC = met.relative_humidity_ice.to_numpy()
-    alt_m = met.altitude.to_numpy() * 1e3 # km to m
+    alt_m = met.altitude.to_numpy() * 1e3  # km to m
 
-    plt.plot(RHi_PC, alt_m, color = 'b', lw = 1.5)
+    plt.plot(RHi_PC, alt_m, color="b", lw=1.5)
     plt.ylabel("Altitude, m")
-    plt.xlabel('RHi, %')
+    plt.xlabel("RHi, %")
     plt.yticks([9000, 9500, 10000, 10500, 11000])
-    plt.ylim(9000,11000)
-    plt.xlim(0,150)
+    plt.ylim(9000, 11000)
+    plt.xlim(0, 150)
     plt.show()

--- a/scripts/simple_met_input/src/ISA.py
+++ b/scripts/simple_met_input/src/ISA.py
@@ -6,49 +6,52 @@ import numpy as np
 
 # TODO: Include humidity in these calculations...
 
+
 class ISA:
     # ISA temperature lapse rate magnitude at the troposphere
-    alpha = 6.5e-3 # K / m
+    alpha = 6.5e-3  # K / m
 
     # Perfect gas constant for air
-    R = 287.053 # J / kg K
+    R = 287.053  # J / kg K
 
     # Acceleration due to gravity
-    g = 9.80665 # m / s^2
+    g = 9.80665  # m / s^2
 
     # Sea level quantities
-    T_0 = 288.15 # K
-    p_0 = 101325 # Pa
-    rho_0 = 1.225 # kg / m^3
+    T_0 = 288.15  # K
+    p_0 = 101325  # Pa
+    rho_0 = 1.225  # kg / m^3
 
     # Sea level temperature offfset
-    T_offset = 0 # K
+    T_offset = 0  # K
 
     # Quantities at the tropopause (11000m AMSL)
-    h_11 = 11000 # m AMSL
-    p_11 = np.nan # Calculated during the object initialisation
-    T_11 = np.nan # Calculated during the object initialisation
+    h_11 = 11000  # m AMSL
+    p_11 = np.nan  # Calculated during the object initialisation
+    T_11 = np.nan  # Calculated during the object initialisation
 
-    def __init__(self, T_offset_K = 0):
+    def __init__(self, T_offset_K=0):
         # Evaluate the quantities at the tropopause (11000m AMSL) upon initialisation
         # according to the International Standard Atmosphere equations from the following link:
-        #  
-        # https://eng.libretexts.org/Bookshelves/Aerospace_Engineering/Fundamentals_of_Aerospace_Engineering_(Arnedo)/02%3A_Generalities/2.03%3A_Standard_atmosphere    
+        #
+        # https://eng.libretexts.org/Bookshelves/Aerospace_Engineering/Fundamentals_of_Aerospace_Engineering_(Arnedo)/02%3A_Generalities/2.03%3A_Standard_atmosphere
 
         self.T_offset = T_offset_K
-        
-        self.p_11 = self.p_0 * np.power(1 - self.alpha / self.T_0 * self.h_11,
-                                        self.g / self.R / self.alpha)
+
+        self.p_11 = self.p_0 * np.power(
+            1 - self.alpha / self.T_0 * self.h_11, self.g / self.R / self.alpha
+        )
         T_11 = self.T_0 - self.alpha * self.h_11 + self.T_offset
-        
+
     def compute_p_from_h(self, h_m):
         # Returns the pressure (in Pa) at a given altitude h (in metres AMSL)
         # according to the International Standard Atmosphere equations from the following link:
-        #  
-        # https://eng.libretexts.org/Bookshelves/Aerospace_Engineering/Fundamentals_of_Aerospace_Engineering_(Arnedo)/02%3A_Generalities/2.03%3A_Standard_atmosphere        
-        
-        p_troposphere_Pa = self.p_0 * np.power(1 - self.alpha / self.T_0 * h_m,
-                                            self.g / self.R / self.alpha)
+        #
+        # https://eng.libretexts.org/Bookshelves/Aerospace_Engineering/Fundamentals_of_Aerospace_Engineering_(Arnedo)/02%3A_Generalities/2.03%3A_Standard_atmosphere
+
+        p_troposphere_Pa = self.p_0 * np.power(
+            1 - self.alpha / self.T_0 * h_m, self.g / self.R / self.alpha
+        )
         p_stratosphere_Pa = self.p_11 * np.exp(-self.g / self.R / self.T_11 * (h_m - self.h_11))
 
         p_out_Pa = np.where(h_m <= self.h_11, p_troposphere_Pa, p_stratosphere_Pa)
@@ -59,9 +62,9 @@ class ISA:
     def compute_T_from_h(self, h_m):
         # Returns the temperature (in degrees K) at a given altitude h (in metres AMSL)
         # according to the International Standard Atmosphere equations from the following link:
-        #    
+        #
         # https://eng.libretexts.org/Bookshelves/Aerospace_Engineering/Fundamentals_of_Aerospace_Engineering_(Arnedo)/02%3A_Generalities/2.03%3A_Standard_atmosphere
-        
+
         T_troposphere_K = self.T_0 - self.alpha * h_m
         T_stratosphere_K = self.T_11
 
@@ -75,46 +78,50 @@ class ISA:
         # according to the ideal gas law.
         #
         # NOTE: NO DISTINCTION IS MADE BETWEEN DRY AND HUMID AIR DENSITY HERE!
-        
-        p_Pa =  self.compute_p_from_h(h_m)
-        T_K =  self.compute_T_from_h(h_m)
+
+        p_Pa = self.compute_p_from_h(h_m)
+        T_K = self.compute_T_from_h(h_m)
 
         return p_Pa / (self.R * T_K)
 
     def compute_h_from_p(self, p_Pa):
         # Returns the altitude (in metres AMSL) at a given altitude ambient pressure (in Pa)
         # according to the International Standard Atmosphere equations from the following link:
-        #    
+        #
         # https://eng.libretexts.org/Bookshelves/Aerospace_Engineering/Fundamentals_of_Aerospace_Engineering_(Arnedo)/02%3A_Generalities/2.03%3A_Standard_atmosphere
-        
-        h_troposphere_m = self.T_0 / self.alpha * ( 1 - np.power(p_Pa / self.p_0,
-                                                               self.R * self.alpha / self.g) )
+
+        h_troposphere_m = (
+            self.T_0 / self.alpha * (1 - np.power(p_Pa / self.p_0, self.R * self.alpha / self.g))
+        )
         h_stratosphere_m = self.h_11 - self.R * self.T_11 / self.g * np.log(p_Pa / self.p_11)
-        
+
         h_out_m = np.where(p_Pa >= self.p_11, h_troposphere_m, h_stratosphere_m)
 
         # Enforce altitudes beneath SL to be equal to the SL.
         return np.where(h_out_m < 0, 0, h_out_m)
 
+
 def compute_p_ISA(h_m):
     # Returns the pressure (in Pa) at a given altitude h (in metres AMSL)
     # according to the International Standard Atmosphere equations from the following link:
     #
-    # https://eng.libretexts.org/Bookshelves/Aerospace_Engineering/Fundamentals_of_Aerospace_Engineering_(Arnedo)/02%3A_Generalities/2.03%3A_Standard_atmosphere        
-    
+    # https://eng.libretexts.org/Bookshelves/Aerospace_Engineering/Fundamentals_of_Aerospace_Engineering_(Arnedo)/02%3A_Generalities/2.03%3A_Standard_atmosphere
+
     ISA_computer = ISA()
     return ISA_computer.compute_p_from_h(h_m)
 
-def compute_T_ISA(h_m, T_offset_K = 0):
+
+def compute_T_ISA(h_m, T_offset_K=0):
     # Returns the temperature (in degrees K) at a given altitude h (in metres AMSL)
     # according to the International Standard Atmosphere equations from the following link:
-    #  
+    #
     # https://eng.libretexts.org/Bookshelves/Aerospace_Engineering/Fundamentals_of_Aerospace_Engineering_(Arnedo)/02%3A_Generalities/2.03%3A_Standard_atmosphere
-    
+
     ISA_computer = ISA(T_offset_K)
     return ISA_computer.compute_T_from_h(h_m)
 
-def compute_rho_ISA(h_m, T_offset_K = 0):
+
+def compute_rho_ISA(h_m, T_offset_K=0):
     # Returns the air density (in kg / m^3) at a given altitude h (in metres AMSL)
     # according to the ideal gas law.
     #
@@ -123,11 +130,12 @@ def compute_rho_ISA(h_m, T_offset_K = 0):
     ISA_computer = ISA(T_offset_K)
     return ISA_computer.compute_rho_from_h(h_m)
 
+
 def compute_h_from_p_ISA(p_Pa):
     # Returns the altitude (in metres AMSL) at a given altitude ambient pressure (in Pa)
     # according to the International Standard Atmosphere equations from the following link:
-    #    
+    #
     # https://eng.libretexts.org/Bookshelves/Aerospace_Engineering/Fundamentals_of_Aerospace_Engineering_(Arnedo)/02%3A_Generalities/2.03%3A_Standard_atmosphere
-    
+
     ISA_computer = ISA()
     return ISA_computer.compute_h_from_p(p_Pa)

--- a/scripts/simple_met_input/src/met.py
+++ b/scripts/simple_met_input/src/met.py
@@ -1,110 +1,126 @@
 import xarray as xr
 import numpy as np
-import matplotlib.pyplot as plt
 
 from pathlib import Path
 from src.ISA import compute_T_ISA, compute_p_ISA
 from src.moist import trapezium_moist_layer
-from src.thermo import convert_RHi_to_RH
 
-def met_clean_slate(desired_altitudes_m, desired_RHis_PC = None, RHi_background_PC = 0., shear_over_s = 0.002, T_offset_K = 0,
-                    w_m_per_s = 0):
+
+def met_clean_slate(
+    desired_altitudes_m,
+    desired_RHis_PC=None,
+    RHi_background_PC=0.0,
+    shear_over_s=0.002,
+    T_offset_K=0,
+    w_Pa_per_s=0,
+):
     # Creates a clean slate xr.Dataset object with the weather parameters required by APCEMM at
     # each altitude. The vertical resolution is determined by the "desired_altitudes_m" input.
     #
     # The met created by this function is time-invariant and is only defined for 24 hours.
     #
     # This function uses the ISA. However, the temperature offset ("T_offset_K") does not affect the
-    # ISA calculations (which assume zero temperature offset), except for the temperature and density.
+    # ISA calculations (which assume zero temperature offset), except for the temperature and
+    # density.
     #
     # The following weather parameters can be changed:
-    #   - RHi: Must be in %. Set by the use of a vertical profile (set in "desired_RHis_PC") or by the
-    #          use of a constant RHi (set in "RHi_background_PC"; only used when "desired_RHis_PC" is "None").
-    #   - Shear: In units of 1/s. A uniform shear field is assumed. (Set by the "shear_over_s" input.)
+    #   - RHi: Must be in %. Set by the use of a vertical profile (set in "desired_RHis_PC") or by
+    #          the
+    #          use of a constant RHi (set in "RHi_background_PC"; only used when "desired_RHis_PC"
+    #          is "None").
+    #   - Shear: In units of 1/s. A uniform shear field is assumed. (Set by the "shear_over_s"
+    #            input.)
     #   - Temperature offset: In units of K. A linear shift in the ISA temperature, can be either
     #         positive or negative.
+    #   - Vertical velocity of the atmospheric air: Must be in Pa per s set in "w_Pa_per_s".
     #
     # Returns a xr.Dataset object.
 
-    desired_altitudes_km = desired_altitudes_m / 1e3 # m to km
+    desired_altitudes_km = desired_altitudes_m / 1e3  # m to km
 
     # Time vector, just in case it is needed
-    time_ip = np.concatenate((np.linspace(15, 23, 9), np.linspace(0, 14, 15))) # hours
+    time_ip = np.concatenate((np.linspace(15, 23, 9), np.linspace(0, 14, 15)))  # hours
 
     # Initialise the dataset with bad weather data
     met_data_temp = xr.Dataset(
         data_vars=dict(
-            shear=(["altitude"], np.zeros_like(desired_altitudes_m), {'units':'m/s/m'}),
-            stretch=(["time"], np.ones_like(time_ip), {'units':'-'}),
-            pressure=(["altitude"], np.zeros_like(desired_altitudes_m), {'units':'hPa'}),
-            temperature=(["altitude"], np.zeros_like(desired_altitudes_m), {'units':'K'}),
-            w=(["altitude"], np.zeros_like(desired_altitudes_m), {'units':'m s-1'}),
-            relative_humidity_ice=(["altitude"], np.zeros_like(desired_altitudes_m), {'units':'pct'}),
+            shear=(["altitude"], np.zeros_like(desired_altitudes_m), {"units": "m/s/m"}),
+            stretch=(["time"], np.ones_like(time_ip), {"units": "-"}),
+            pressure=(["altitude"], np.zeros_like(desired_altitudes_m), {"units": "hPa"}),
+            temperature=(["altitude"], np.zeros_like(desired_altitudes_m), {"units": "K"}),
+            w=(["altitude"], np.zeros_like(desired_altitudes_m), {"units": "Pa s-1"}),
+            relative_humidity_ice=(
+                ["altitude"],
+                np.zeros_like(desired_altitudes_m),
+                {"units": "pct"},
+            ),
         ),
         coords=dict(
-            altitude=(["altitude"], desired_altitudes_km, {'units':'km'}),
-            time=(["time"], time_ip, {'units':'h'}),
-            reference_time=(np.datetime64('2019-01-01T00:00'))         
+            altitude=(["altitude"], desired_altitudes_km, {"units": "km"}),
+            time=(["time"], time_ip, {"units": "h"}),
+            reference_time=(np.datetime64("2019-01-01T00:00")),
         ),
     )
 
     if desired_RHis_PC is None:
         met_data_ISA = met_from_ISA(
-            met = met_data_temp,
-            RHi_background_PC = RHi_background_PC,
-            T_offset_K = T_offset_K,
-            shear_over_s = shear_over_s,
-            w_m_per_s = w_m_per_s
-            )
+            met=met_data_temp,
+            RHi_background_PC=RHi_background_PC,
+            T_offset_K=T_offset_K,
+            shear_over_s=shear_over_s,
+            w_Pa_per_s=w_Pa_per_s,
+        )
     else:
         RHi_background_PC = np.min(desired_RHis_PC)
         met_data_ISA = met_from_ISA(
-            met = met_data_temp,
-            RHi_background_PC = RHi_background_PC,
-            T_offset_K = T_offset_K,
-            shear_over_s = shear_over_s,
-            w_m_per_s = w_m_per_s
-            )
-        
+            met=met_data_temp,
+            RHi_background_PC=RHi_background_PC,
+            T_offset_K=T_offset_K,
+            shear_over_s=shear_over_s,
+            w_Pa_per_s=w_Pa_per_s,
+        )
+
         # Enforce the desired RHis to each altitude
         RHi = met_data_ISA.relative_humidity_ice
 
         for i in range(len(desired_altitudes_km)):
             current_alt = desired_altitudes_km[i]
             mask = RHi.altitude != current_alt
-            RHi = RHi.where(mask, desired_RHis_PC[i]) 
+            RHi = RHi.where(mask, desired_RHis_PC[i])
 
         met_data_ISA["relative_humidity_ice"] = RHi
-        
 
     return met_data_ISA
 
-def truncate_met(met, truncation_alt_km = 20.):
+
+def truncate_met(met, truncation_alt_km=20.0):
     # Truncates the APCEMM met data to remain beneath the tropopause.
 
-    altitudes = met.altitude # km
+    altitudes = met.altitude  # km
     truncation_idx = len(altitudes)
 
     # Find the index at which the altitude surpasses the truncation threshold
     for i in range(len(altitudes)):
-        if (altitudes[i] > truncation_alt_km):
+        if altitudes[i] > truncation_alt_km:
             truncation_idx = i
             break
 
-    return met.isel(altitude = slice(0, truncation_idx))
+    return met.isel(altitude=slice(0, truncation_idx))
 
-def met_from_ISA(met, RHi_background_PC = 0., shear_over_s = 0.002, T_offset_K = 0, w_m_per_s = 0):
+
+def met_from_ISA(met, RHi_background_PC=0.0, shear_over_s=0.002, T_offset_K=0, w_Pa_per_s=0):
     # Clears the existing temperature values of an input xr.Dataset ("met"), and
     # enforces ISA conditions at each point.
     #
     # The met created by this function is time-invariant and is only defined for 24 hours.
     #
-    # The temperature offset ("T_offset_K") does not affect the ISA calculations (which 
+    # The temperature offset ("T_offset_K") does not affect the ISA calculations (which
     # assume zero temperature offset), except for the temperature itself.
     #
     # The following weather parameters can be changed:
     #   - Background RHi: Must be in %. Set by the use of "RHi_background_PC".
-    #   - Shear: In units of 1/s. A uniform shear field is assumed. (Set by the "shear_over_s" input.)
+    #   - Shear: In units of 1/s. A uniform shear field is assumed. (Set by the "shear_over_s"
+    #            input.)
     #   - Temperature offset: In units of K. A shift in the ISA temperature, can be either
     #         positive or negative. Does not affect the other ISA parameters.
     #
@@ -117,9 +133,9 @@ def met_from_ISA(met, RHi_background_PC = 0., shear_over_s = 0.002, T_offset_K =
 
     # Enforce the ISA conditions at each altitude
     for i in range(len(altitudes)):
-        h_current = altitudes[i] * 1000 # km to m
+        h_current = altitudes[i] * 1000  # km to m
         T_current = compute_T_ISA(h_current, T_offset_K)
-        p_current = compute_p_ISA(h_current) / 100. # Pa to hPa
+        p_current = compute_p_ISA(h_current) / 100.0  # Pa to hPa
 
         mask = met.altitude != altitudes[i]
         T = T.where(mask, T_current)
@@ -140,30 +156,44 @@ def met_from_ISA(met, RHi_background_PC = 0., shear_over_s = 0.002, T_offset_K =
 
     # Set the vertical velocity of the met data to the RHi default value
     w_met = met["w"]
-    w_met = w_met.where(False, w_m_per_s)
+    w_met = w_met.where(False, w_Pa_per_s)
     met["w"] = w_met
 
     return met
 
-def create_and_save_met(alts_m, RHis_PC, T_offset_K = 0, shear_over_s = 0.002, w_m_per_s = 0, prefix = "00"):
+
+def create_and_save_met(
+    alts_m, RHis_PC, T_offset_K=0, shear_over_s=0.002, w_Pa_per_s=0, prefix="00"
+):
     met = met_clean_slate(
-        desired_altitudes_m = alts_m,
-        desired_RHis_PC = RHis_PC,
-        T_offset_K = T_offset_K,
-        shear_over_s = shear_over_s,
-        w_m_per_s = w_m_per_s
-        )
-    
+        desired_altitudes_m=alts_m,
+        desired_RHis_PC=RHis_PC,
+        T_offset_K=T_offset_K,
+        shear_over_s=shear_over_s,
+        w_Pa_per_s=w_Pa_per_s,
+    )
+
     Path("outputs/").mkdir(parents=True, exist_ok=True)
-    met.to_netcdf('outputs/' + prefix + '-met.nc', engine="netcdf4")
+    met.to_netcdf("outputs/" + prefix + "-met.nc", engine="netcdf4")
     return met
 
-def make_idealised_met(centre_altitude_m, moist_depth_m, RHi_background_PC = 0., RHi_peak_PC = 150, 
-                grad_RHi_PC_per_m = None, alt_resolution_m = 100, upper_alt_m = 11001, shear_over_s = 2e-3,
-                T_offset_K = 0, w_m_per_s = 0, filename_prefix = "default"):
+
+def make_idealised_met(
+    centre_altitude_m,
+    moist_depth_m,
+    RHi_background_PC=0.0,
+    RHi_peak_PC=150,
+    grad_RHi_PC_per_m=None,
+    alt_resolution_m=100,
+    upper_alt_m=11001,
+    shear_over_s=2e-3,
+    T_offset_K=0,
+    w_Pa_per_s=0,
+    filename_prefix="default",
+):
     # Creates an idealised met file with a trapezium moist layer.
     #
-    # The altitude is sampled at intervals with spacing of alt_resolution_m, up until 
+    # The altitude is sampled at intervals with spacing of alt_resolution_m, up until
     # upper_alt_m (not inclusive of this)
     #
     # The depth of the moist region indicates where the relative humidity is above background
@@ -173,20 +203,24 @@ def make_idealised_met(centre_altitude_m, moist_depth_m, RHi_background_PC = 0.,
     # narrow, the peak RHi will not be reached anywhere in the moist region.
     #
     # The met created by this function is time-invariant and is only defined for 24 hours.
-    
-    altitudes, RHis = trapezium_moist_layer(centre_altitude_m = centre_altitude_m,
-                                            moist_depth_m = moist_depth_m,
-                                            RHi_background_PC = RHi_background_PC, 
-                                            RHi_peak_PC = RHi_peak_PC,
-                                            grad_RHi_PC_per_m = grad_RHi_PC_per_m,
-                                            alt_resolution_m = alt_resolution_m, 
-                                            upper_alt_m = upper_alt_m)
-    
-    met = create_and_save_met(alts_m = altitudes,
-                              RHis_PC = RHis,
-                              T_offset_K = T_offset_K,
-                              shear_over_s = shear_over_s,
-                              w_m_per_s = w_m_per_s,
-                              prefix = filename_prefix)
+
+    altitudes, RHis = trapezium_moist_layer(
+        centre_altitude_m=centre_altitude_m,
+        moist_depth_m=moist_depth_m,
+        RHi_background_PC=RHi_background_PC,
+        RHi_peak_PC=RHi_peak_PC,
+        grad_RHi_PC_per_m=grad_RHi_PC_per_m,
+        alt_resolution_m=alt_resolution_m,
+        upper_alt_m=upper_alt_m,
+    )
+
+    met = create_and_save_met(
+        alts_m=altitudes,
+        RHis_PC=RHis,
+        T_offset_K=T_offset_K,
+        shear_over_s=shear_over_s,
+        w_Pa_per_s=w_Pa_per_s,
+        prefix=filename_prefix,
+    )
 
     return met

--- a/scripts/simple_met_input/src/moist.py
+++ b/scripts/simple_met_input/src/moist.py
@@ -4,28 +4,36 @@ import numpy as np
 ##    Moist layer shape Creation
 ######
 
-def trapezium_moist_layer(centre_altitude_m, moist_depth_m, RHi_background_PC = 0., RHi_peak_PC = 150, 
-                grad_RHi_PC_per_m = None, alt_resolution_m = 100, upper_alt_m = 11001):
+
+def trapezium_moist_layer(
+    centre_altitude_m,
+    moist_depth_m,
+    RHi_background_PC=0.0,
+    RHi_peak_PC=150,
+    grad_RHi_PC_per_m=None,
+    alt_resolution_m=100,
+    upper_alt_m=11001,
+):
     # Creates a RHi (%) and altitude (m) vector that represents a trapezium in an alt vs RHi
     # graph to simulate a moist region.
     #
-    # The altitude is sampled at intervals with spacing of alt_resolution_m, up until 
+    # The altitude is sampled at intervals with spacing of alt_resolution_m, up until
     # upper_alt_m (not inclusive of this)
     #
     # The depth of the moist region indicates where the relative humidity is above background
     # levels.
-    # 
+    #
     # The generated trapezium is defined from the sides inwards, meaning that if it is too
     # narrow, the peak RHi will not be reached anywhere in the moist region.
-   
+
     altitudes_m = np.arange(start=0, stop=upper_alt_m, step=alt_resolution_m)
 
     # Add the missing key points to the altutude array
     if not np.any(altitudes_m == centre_altitude_m):
         altitudes_m = np.append(altitudes_m, centre_altitude_m)
 
-    thresh_upper_m = centre_altitude_m + moist_depth_m / 2.
-    thresh_lower_m = centre_altitude_m - moist_depth_m / 2.
+    thresh_upper_m = centre_altitude_m + moist_depth_m / 2.0
+    thresh_lower_m = centre_altitude_m - moist_depth_m / 2.0
 
     if not np.any(altitudes_m == thresh_upper_m):
         altitudes_m = np.append(altitudes_m, thresh_upper_m)
@@ -71,10 +79,14 @@ def trapezium_moist_layer(centre_altitude_m, moist_depth_m, RHi_background_PC = 
             if (current_alt_m < thresh_lower_m) or (current_alt_m > thresh_upper_m):
                 continue
 
-            if (current_alt_m <= thresh_2_m):
-                RHis_PC[i] = RHi_background_PC + (current_alt_m - thresh_lower_m) * grad_RHi_PC_per_m
+            if current_alt_m <= thresh_2_m:
+                RHis_PC[i] = (
+                    RHi_background_PC + (current_alt_m - thresh_lower_m) * grad_RHi_PC_per_m
+                )
 
-            if (current_alt_m >= thresh_3_m):
-                RHis_PC[i] = RHi_background_PC + (thresh_upper_m - current_alt_m) * grad_RHi_PC_per_m
+            if current_alt_m >= thresh_3_m:
+                RHis_PC[i] = (
+                    RHi_background_PC + (thresh_upper_m - current_alt_m) * grad_RHi_PC_per_m
+                )
 
     return altitudes_m, RHis_PC

--- a/scripts/simple_met_input/src/thermo.py
+++ b/scripts/simple_met_input/src/thermo.py
@@ -1,10 +1,11 @@
 import numpy as np
 
+
 ######################### WATER THERMODYNAMIC FUNCTIONS #########################
 def compute_p_sat_liq(T_K):
     # Calculates the liquid saturation pressure "p_sat_liq" (in units of Pa).
     # This equation can be found in Schumann 2012.
-    # 
+    #
     # The inputs are as follows:
     # - T_K is the absolute temperature in Kelvin
 
@@ -16,10 +17,11 @@ def compute_p_sat_liq(T_K):
 
     return 100 * np.exp(a / T_K + b + c * T_K + d * T_K * T_K + e * np.log(T_K))
 
+
 def compute_p_sat_ice(T_K):
     # Calculates the ice saturation pressure "p_sat_ice" (in units of Pa)
     # The equation can be found in Schumann 2012.
-    #  
+    #
     # The inputs are as follows
     # - T_K is the absolute temperature in Kelvin
 
@@ -31,50 +33,60 @@ def compute_p_sat_ice(T_K):
 
     return 100 * np.exp(a / T_K + b + c * T_K + d * T_K * T_K + e * np.log(T_K))
 
+
 def convert_RH_to_RHi(T_K, RH):
     return RH * compute_p_sat_liq(T_K) / compute_p_sat_ice(T_K)
 
+
 def convert_RHi_to_RH(T_K, RHi):
     return RHi * compute_p_sat_ice(T_K) / compute_p_sat_liq(T_K)
+
 
 def convert_RH_to_SH(T_K, p_Pa, RH_PC):
     # Implements the equations from https://earthscience.stackexchange.com/a/2361
     # The output specific humidity is in ratio format.
     # The input RH must be in %.
 
-    RH_ratio = RH_PC / 100.
-    R_d = 287 # J kg^-1 K^-1 from https://en.wikipedia.org/wiki/Gas_constant#:~:text=Specific%20gas%20constant,-Rspecific&text=for%20dry%20air%20of%2028.964917%20g%2Fmol.
-    R_v = 461.5 # J kg^-1 K^-1 from https://en.wikipedia.org/wiki/Water_vapor
+    RH_ratio = RH_PC / 100.0
+    R_d = 287  # J kg^-1 K^-1 from https://en.wikipedia.org/wiki/Gas_constant#:~:text=Specific%20gas%20constant,-Rspecific&text=for%20dry%20air%20of%2028.964917%20g%2Fmol.
+    R_v = 461.5  # J kg^-1 K^-1 from https://en.wikipedia.org/wiki/Water_vapor
 
-    e_s_Pa = compute_p_sat_liq(T_K) # Saturation pressure of water vapour
-    w_s = (R_d / R_v) * e_s_Pa / (p_Pa - e_s_Pa) # Mass mixing ratio of water vapor to dry air at equilibrium (dimensionless)
+    e_s_Pa = compute_p_sat_liq(T_K)  # Saturation pressure of water vapour
+    w_s = (
+        (R_d / R_v) * e_s_Pa / (p_Pa - e_s_Pa)
+    )  # Mass mixing ratio of water vapor to dry air at equilibrium (dimensionless)
 
-    w = RH_ratio * w_s # Mass mixing ratio of water vapor to dry air
+    w = RH_ratio * w_s  # Mass mixing ratio of water vapor to dry air
 
     return w / (w + 1)
+
 
 def convert_RHi_to_SH(T_K, p_Pa, RHi_PC):
     # Implements the equations from https://earthscience.stackexchange.com/a/2361
     # The output specific humidity is in ratio format.
     # The input RHi must be in %.
-    
+
     RH_PC = convert_RHi_to_RH(T_K, RHi_PC)
 
     return convert_RH_to_SH(T_K, p_Pa, RH_PC)
+
 
 def convert_SH_to_RH(T_K, p_Pa, SH):
     # Implements the equations from https://earthscience.stackexchange.com/a/2361
     # The specific humidity must be in ratio format. The output RH is in %
 
-    R_d = 287 # J kg^-1 K^-1 from https://en.wikipedia.org/wiki/Gas_constant#:~:text=Specific%20gas%20constant,-Rspecific&text=for%20dry%20air%20of%2028.964917%20g%2Fmol.
-    R_v = 461.5 # J kg^-1 K^-1 from https://en.wikipedia.org/wiki/Water_vapor
+    R_d = 287  # J kg^-1 K^-1 from https://en.wikipedia.org/wiki/Gas_constant#:~:text=Specific%20gas%20constant,-Rspecific&text=for%20dry%20air%20of%2028.964917%20g%2Fmol.
+    R_v = 461.5  # J kg^-1 K^-1 from https://en.wikipedia.org/wiki/Water_vapor
 
-    e_s_Pa = compute_p_sat_liq(T_K) # Saturation pressure of water vapour
-    w_s = (R_d / R_v) * e_s_Pa / (p_Pa - e_s_Pa) # Mass mixing ratio of water vapor to dry air at equilibrium (dimensionless)
+    e_s_Pa = compute_p_sat_liq(T_K)  # Saturation pressure of water vapour
+    w_s = (
+        (R_d / R_v) * e_s_Pa / (p_Pa - e_s_Pa)
+    )  # Mass mixing ratio of water vapor to dry air at equilibrium (dimensionless)
 
     w = SH / (1 - SH)
-    
+
     return w / w_s * 100
+
 
 def convert_SH_to_RHi(T_K, p_Pa, SH):
     # Implements the equations from https://earthscience.stackexchange.com/a/2361


### PR DESCRIPTION
I noticed that as of version 1.2 the met files produced by the scripts are no longer compatible with APCEMM.

This PR addresses that by:
- Adding a way to specify the vertical velocity "w".
- Adding a default entry (populated by ones) for the stretch.
- Adding a reference time.
- Removing the water relative humidity.

