### PR TITLE
Enable RNG seed choice from input.yaml

### DIFF
--- a/Code.v05-00/include/Core/Input_Mod.hpp
+++ b/Code.v05-00/include/Core/Input_Mod.hpp
@@ -43,6 +43,8 @@ struct OptInput
     std::string SIMULATION_ADJOINT_FILENAME;
     bool        SIMULATION_BOXMODEL;
     std::string SIMULATION_BOX_FILENAME;
+    bool        SIMULATION_FORCE_SEED;
+    int         SIMULATION_SEED_VALUE;
 
     /* ========================================== */
     /* ---- PARAMETER MENU ---------------------- */

--- a/Code.v05-00/include/Util/MC_Rand.hpp
+++ b/Code.v05-00/include/Util/MC_Rand.hpp
@@ -15,9 +15,10 @@
 #define MC_RAND_H_INCLUDED
 
 #include <cstdlib>
+#include "Core/Input_Mod.hpp"
 
 /* Set seed for pseudo-random generator */
-void setSeed();
+void setSeed(const OptInput& input);
 
 /* Generates a random number of type T between fMin and fMax */
 template <typename T>

--- a/Code.v05-00/include/YamlInputReader/YamlInputReader.hpp
+++ b/Code.v05-00/include/YamlInputReader/YamlInputReader.hpp
@@ -14,7 +14,7 @@ using std::vector;
 namespace YamlInputReader{
     static std::filesystem::path INPUT_FILE_PATH;
     void readYamlInputFile(OptInput& input, string filename);
-    void readSimMenu(OptInput& input, const YAML::Node& inputNode);
+    void readSimMenu(OptInput& input, const YAML::Node& simNode);
     void readParamMenu(OptInput& input, const YAML::Node& paramNode);
     void readTransportMenu(OptInput& input, const YAML::Node& transportNode);
     void readChemMenu(OptInput& input, const YAML::Node& chemNode);

--- a/Code.v05-00/src/Core/Main.cpp
+++ b/Code.v05-00/src/Core/Main.cpp
@@ -62,9 +62,6 @@ int main( int argc, char* argv[])
         std::cout << "-------- DEBUG is enabled --------" << std::endl;
     #endif
 
-    // Set the seed once at the top-level
-    setSeed();
-
     /* Declaring the Input Option object for use in APCEMM */
     OptInput Input_Opt; // Input Option object
 
@@ -98,9 +95,15 @@ int main( int argc, char* argv[])
         std::string FILENAME = argv[1];
         std::filesystem::path INPUT_FILE_PATH(FILENAME);
         INPUT_FILE_PATH = std::filesystem::canonical(INPUT_FILE_PATH);
-
+        
         YamlInputReader::readYamlInputFile( Input_Opt, INPUT_FILE_PATH.generic_string() );
+    }  /* master CPU */
 
+    // Set the seed once at the top-level
+    setSeed( Input_Opt );
+
+    #pragma omp master
+    {
         /* Collect parameters and create cases */
         parameters = YamlInputReader::generateCases( Input_Opt );
 

--- a/Code.v05-00/src/Util/MC_Rand.cpp
+++ b/Code.v05-00/src/Util/MC_Rand.cpp
@@ -13,8 +13,9 @@
 #include <iostream>
 #include "APCEMM.h"
 #include "Util/MC_Rand.hpp"
+#include "Core/Input_Mod.hpp"
 
-void setSeed() {
+void setSeed(const OptInput& input) {
 
     // Sets seed for pseudo-random generator.
     #ifdef DEBUG
@@ -22,8 +23,15 @@ void setSeed() {
         std::cout << "Compiled in DEBUG mode: random seed is set to 0 for all simulations" << std::endl;
         srand(0);
     #else
-        // Otherwise use the current unix timestamp as our random seed. 
-        srand(time(NULL));
+        if(input.SIMULATION_FORCE_SEED){
+            srand(input.SIMULATION_SEED_VALUE);
+            std::cout << "Random seed is set to " << input.SIMULATION_SEED_VALUE << " for all simulations" << std::endl;
+        }
+        else{
+            // If the seed is not being forced to a value use the current unix timestamp instead. 
+            srand(time(NULL));
+        }
+
     #endif
 
 } /* End of setSeed */

--- a/Code.v05-00/src/YamlInputReader/YamlInputReader.cpp
+++ b/Code.v05-00/src/YamlInputReader/YamlInputReader.cpp
@@ -89,7 +89,7 @@ namespace YamlInputReader{
         #endif
 
         YAML::Node paramSweepSubmenu = simNode["PARAM SWEEP SUBMENU"];
-        input.SIMULATION_PARAMETER_SWEEP = parseBoolString(paramSweepSubmenu["Parameter sweep (T/F)"].as<string>(), "Parameter sweep (T/F");
+        input.SIMULATION_PARAMETER_SWEEP = parseBoolString(paramSweepSubmenu["Parameter sweep (T/F)"].as<string>(), "Parameter sweep (T/F)");
         input.SIMULATION_MONTECARLO = parseBoolString(paramSweepSubmenu["Run Monte Carlo (T/F)"].as<string>(), "Run Monte Carlo (T/F)");
         input.SIMULATION_MCRUNS =  parseIntString(paramSweepSubmenu["Num Monte Carlo runs (int)"].as<string>(), "Num Monte Carlo runs (int)");
 
@@ -118,6 +118,13 @@ namespace YamlInputReader{
         YAML::Node boxModelSubmenu = simNode["BOX MODEL SUBMENU"];
         input.SIMULATION_BOXMODEL = parseBoolString(boxModelSubmenu["Run box model (T/F)"].as<string>(), "Run box model (T/F)");
         input.SIMULATION_BOX_FILENAME = boxModelSubmenu["netCDF filename format (string)"].as<string>();
+
+        YAML::Node seedSubmenu = simNode["RANDOM NUMBER GENERATION SUBMENU"];
+        input.SIMULATION_FORCE_SEED = parseBoolString(seedSubmenu["Force seed value (T/F)"].as<string>(), "Force seed value (T/F)");
+        input.SIMULATION_SEED_VALUE = parseIntString(seedSubmenu["Seed value (positive int)"].as<string>(), "Seed value (positive int)");
+        if(input.SIMULATION_SEED_VALUE < 0){
+            throw std::invalid_argument("Seed value (under SIMULATION MENU) cannot be less than 0!");
+        }
 
         if(input.SIMULATION_PARAMETER_SWEEP == input.SIMULATION_MONTECARLO){
             throw std::invalid_argument("In Simulation Menu: Parameter sweep and Monte Carlo cannot have the same value!");

--- a/examples/issl_rhi140/input.yaml
+++ b/examples/issl_rhi140/input.yaml
@@ -31,6 +31,9 @@ SIMULATION MENU:
   BOX MODEL SUBMENU:
     Run box model (T/F): F
     netCDF filename format (string): APCEMM_BOX_CASE_*
+  RANDOM NUMBER GENERATION SUBMENU:
+    Force seed value (T/F): F
+    Seed value (positive int): 0
 
 # Format of parameter items:
 # Param name [unit] (Variable type)

--- a/rundirs/SampleRunDir/input.yaml
+++ b/rundirs/SampleRunDir/input.yaml
@@ -31,6 +31,9 @@ SIMULATION MENU:
   BOX MODEL SUBMENU:
     Run box model (T/F): F
     netCDF filename format (string): APCEMM_BOX_CASE_*
+  RANDOM NUMBER GENERATION SUBMENU:
+    Force seed value (T/F): F
+    Seed value (positive int): 0
 
 # Format of parameter items:
 # Param name [unit] (Variable type)


### PR DESCRIPTION
This PR adds an option to the `input.yaml` file to choose whether to set the random number generation seed to a specified value, also in the input.yaml file.

**Changes**
- `setSeed()` now takes in the `OptInput` object, and is called after the `input.yaml` file has been read
- Stylistic change in `YamlInputReader.cpp`
- Minor bugfix in line 92 of `YamlInputReader.cpp` (missing bracket from a string)

**Notes**
- The default behaviour in the examples is to not force any value of the RNG seed. Instead, the current unix timestamp is used (this was the previous behaviour). 
- The seed is always forced to 0 if APCEMM is compiled in `DEBUG` mode, which also matches the legacy behaviour.

**Testing**
Currently running a suite of runs on both Docker and the Cambridge HPC.