### PR TITLE
Fixed bad behaviour when met file extends far beyond the target domain

### DIFF
--- a/Code.v05-00/src/Core/Meteorology.cpp
+++ b/Code.v05-00/src/Core/Meteorology.cpp
@@ -125,7 +125,7 @@ void Meteorology::estimateSimulationGridPressures(){
         if (zNext > zCeil){
             continue;
         }
-        pressureBase = pressureCeil;
+        pressureBase = (i == 0) ? pressureEdgesInit_[0] : pressureInit_[i-1];
         pressureCeil = (i == (altitudeDim_)) ? pressureTop : pressureInit_[i];
         double lapseRate = lapseInit_[i];
         // If i < 1 this will cause problems, but that should not be possible


### PR DESCRIPTION
This bugfix resolves issue #53 . If the met file extends significantly beyond the lower limit of the target region, the lowermost pressure edge is still (erroneously) used to calculate pressure edges of the simulation grid edges. The first time a new met layer is encountered, the lower pressure edge will suddenly "jump" causing a layer to exist which has a very large and non-physical pressure thickness.

If the met data is relatively fine (high vertical grid resolution) this won't cause an issue, as the first time this happens will likely be outside the zone where ice crystals can reach. However, if the met data is very sparse - as, for example, in the case of ECMWF pressure level output - this will cause chaos, specifically during the remapping stage which relies on a consistent relationship between pressure and altitude. This bugfix resolves the issue by ensuring that the correct pressure edges are used from the met data.