### PR TITLE
Seed menu now optional

### DIFF
--- a/Code.v05-00/src/Core/LAGRIDPlumeModel.cpp
+++ b/Code.v05-00/src/Core/LAGRIDPlumeModel.cpp
@@ -131,7 +131,6 @@ SimStatus LAGRIDPlumeModel::runFullModel() {
 
         // Run vertical advection to get the new pressure edges
         if (std::abs(met_.lastOmega()) > 1.0e-10){
-            std::cout << "DEBUG: Applying updraft of " << met_.lastOmega() << " Pa s-1" << std::endl;
             met_.applyUpdraft(timestepVars_.TRANSPORT_DT);
         }
 

--- a/Code.v05-00/src/YamlInputReader/YamlInputReader.cpp
+++ b/Code.v05-00/src/YamlInputReader/YamlInputReader.cpp
@@ -119,11 +119,16 @@ namespace YamlInputReader{
         input.SIMULATION_BOXMODEL = parseBoolString(boxModelSubmenu["Run box model (T/F)"].as<string>(), "Run box model (T/F)");
         input.SIMULATION_BOX_FILENAME = boxModelSubmenu["netCDF filename format (string)"].as<string>();
 
-        YAML::Node seedSubmenu = simNode["RANDOM NUMBER GENERATION SUBMENU"];
-        input.SIMULATION_FORCE_SEED = parseBoolString(seedSubmenu["Force seed value (T/F)"].as<string>(), "Force seed value (T/F)");
-        input.SIMULATION_SEED_VALUE = parseIntString(seedSubmenu["Seed value (positive int)"].as<string>(), "Seed value (positive int)");
-        if(input.SIMULATION_SEED_VALUE < 0){
-            throw std::invalid_argument("Seed value (under SIMULATION MENU) cannot be less than 0!");
+        if (simNode["RANDOM NUMBER GENERATION SUBMENU"]){
+            YAML::Node seedSubmenu = simNode["RANDOM NUMBER GENERATION SUBMENU"];
+            input.SIMULATION_FORCE_SEED = parseBoolString(seedSubmenu["Force seed value (T/F)"].as<string>(), "Force seed value (T/F)");
+            input.SIMULATION_SEED_VALUE = parseIntString(seedSubmenu["Seed value (positive int)"].as<string>(), "Seed value (positive int)");
+            if(input.SIMULATION_SEED_VALUE < 0){
+                throw std::invalid_argument("Seed value (under SIMULATION MENU) cannot be less than 0!");
+            }
+        } else {
+            input.SIMULATION_FORCE_SEED = false;
+            input.SIMULATION_SEED_VALUE = 0;
         }
 
         if(input.SIMULATION_PARAMETER_SWEEP == input.SIMULATION_MONTECARLO){


### PR DESCRIPTION
To allow backwards compatibility with v1.2.0 input files, the seed menu is now optional. If not present in the input file, a random seed will be assigned as usual. This is (essentially) zero diff (hard to test as the random number generator seed is not fixed).