### PR TITLE
Add an option to disable diffusion after a certain amount of time elapsed

### DIFF
--- a/Code.v05-00/include/Core/Input_Mod.hpp
+++ b/Code.v05-00/include/Core/Input_Mod.hpp
@@ -62,6 +62,8 @@ struct OptInput
     bool        TRANSPORT_UPDRAFT;
     double      TRANSPORT_UPDRAFT_TIMESCALE;
     double      TRANSPORT_UPDRAFT_VELOCITY;
+    bool        TRANSPORT_DISABLE_DIFFUSION_AFTER_TIME;
+    double      TRANSPORT_DISABLE_DIFFUSION_TIME;
 
     /* ========================================== */
     /* ---- CHEMISTRY MENU ---------------------- */

--- a/Code.v05-00/include/Core/LAGRIDPlumeModel.hpp
+++ b/Code.v05-00/include/Core/LAGRIDPlumeModel.hpp
@@ -93,7 +93,7 @@ class LAGRIDPlumeModel {
         void initializeGrid();
         void saveTSAerosol();
         void initH2O();
-        void updateDiffVecs();
+        void updateDiffVecs(const bool skipDiffusion);
         bool checkDiffusionSkip();
         void runTransport(double timestep);
         void remapAllVars(double remapTimestep, const std::vector<std::vector<int>>& mask, const VectorUtils::MaskInfo& maskInfo);

--- a/Code.v05-00/include/Core/LAGRIDPlumeModel.hpp
+++ b/Code.v05-00/include/Core/LAGRIDPlumeModel.hpp
@@ -94,6 +94,7 @@ class LAGRIDPlumeModel {
         void saveTSAerosol();
         void initH2O();
         void updateDiffVecs();
+        bool checkDiffusionSkip();
         void runTransport(double timestep);
         void remapAllVars(double remapTimestep, const std::vector<std::vector<int>>& mask, const VectorUtils::MaskInfo& maskInfo);
         std::pair<LAGRID::twoDGridVariable,LAGRID::twoDGridVariable> remapVariable(const VectorUtils::MaskInfo& maskInfo, const BufferInfo& buffers, const Vector_2D& phi, const std::vector<std::vector<int>>& mask);

--- a/Code.v05-00/include/FVM_ANDS/FVM_Solver.hpp
+++ b/Code.v05-00/include/FVM_ANDS/FVM_Solver.hpp
@@ -12,8 +12,8 @@ namespace FVM_ANDS{
             const Eigen::VectorXd& explicitSolve();
             const Eigen::VectorXd& explicitSolve(const Eigen::VectorXd& source);
 
-            const Eigen::VectorXd& operatorSplitSolve(bool parallelAdvection = false, double courant_max = 0.5);
-            void operatorSplitSolve2DVec(Vector_2D& vec, const BoundaryConditions& bc, bool parallelAdvection = false, double courant_max = 0.5);
+            const Eigen::VectorXd& operatorSplitSolve(const bool skipDiffusion, bool parallelAdvection = false, double courant_max = 0.5);
+            void operatorSplitSolve2DVec(Vector_2D& vec, const BoundaryConditions& bc, const bool skipDiffusion, bool parallelAdvection = false, double courant_max = 0.5);
 
             void advectionHalfTimestepSolve(Vector_2D& vec, const BoundaryConditions& bc, double courant_max = 0.5);
 

--- a/Code.v05-00/src/Core/LAGRIDPlumeModel.cpp
+++ b/Code.v05-00/src/Core/LAGRIDPlumeModel.cpp
@@ -437,6 +437,11 @@ void LAGRIDPlumeModel::runTransport(double timestep) {
         //Dont use enhanced diffusion on the H2O (and zero settling velocity)
         FVM_ANDS::FVM_Solver solver(fvmSolverInitParams, xCoords_, yCoords_, ZERO_BC_INIT, FVM_ANDS::std2dVec_to_eigenVec(H2O_));
         solver.updateTimestep(timestep);
+        if skipDiffusion {
+            solver.updateDiffusion(0, 0);
+        } else {
+            solver.updateDiffusion(input_.horizDiff(), input_.vertiDiff());
+        }
         solver.updateDiffusion(input_.horizDiff(), input_.vertiDiff());
         solver.updateAdvection(0, 0, shear_rep_);
 
@@ -465,7 +470,11 @@ void LAGRIDPlumeModel::runTransport(double timestep) {
         //Identical settings to H2O
         FVM_ANDS::FVM_Solver solver(fvmSolverInitParams, xCoords_, yCoords_, ZERO_BC_INIT, FVM_ANDS::std2dVec_to_eigenVec(Contrail_));
         solver.updateTimestep(timestep);
-        solver.updateDiffusion(input_.horizDiff(), input_.vertiDiff());
+        if skipDiffusion {
+            solver.updateDiffusion(0, 0);
+        } else {
+            solver.updateDiffusion(input_.horizDiff(), input_.vertiDiff());
+        }
         solver.updateAdvection(0, 0, shear_rep_);
 
         solver.operatorSplitSolve2DVec(Contrail_, ZERO_BC, skipDiffusion);

--- a/Code.v05-00/src/Core/LAGRIDPlumeModel.cpp
+++ b/Code.v05-00/src/Core/LAGRIDPlumeModel.cpp
@@ -405,10 +405,13 @@ void LAGRIDPlumeModel::runTransport(double timestep) {
 
     const FVM_ANDS::AdvDiffParams fvmSolverInitParams(0, 0, shear_rep_, input_.horizDiff(), input_.vertiDiff(), timestepVars_.TRANSPORT_DT);
     const FVM_ANDS::BoundaryConditions ZERO_BC_INIT = FVM_ANDS::bcFrom2DVector(iceAerosol_.getPDF()[0], true);
-    updateDiffVecs();
 
     //Check if we need to skip diffusion
     bool skipDiffusion = checkDiffusionSkip();
+
+    if (!skipDiffusion) {
+        updateDiffVecs();
+    }
 
     //Transport the Ice Aerosol PDF
     #pragma omp parallel for default(shared)

--- a/Code.v05-00/src/Core/LAGRIDPlumeModel.cpp
+++ b/Code.v05-00/src/Core/LAGRIDPlumeModel.cpp
@@ -437,7 +437,7 @@ void LAGRIDPlumeModel::runTransport(double timestep) {
         //Dont use enhanced diffusion on the H2O (and zero settling velocity)
         FVM_ANDS::FVM_Solver solver(fvmSolverInitParams, xCoords_, yCoords_, ZERO_BC_INIT, FVM_ANDS::std2dVec_to_eigenVec(H2O_));
         solver.updateTimestep(timestep);
-        if skipDiffusion {
+        if (skipDiffusion) {
             solver.updateDiffusion(0, 0);
         } else {
             solver.updateDiffusion(input_.horizDiff(), input_.vertiDiff());
@@ -470,7 +470,7 @@ void LAGRIDPlumeModel::runTransport(double timestep) {
         //Identical settings to H2O
         FVM_ANDS::FVM_Solver solver(fvmSolverInitParams, xCoords_, yCoords_, ZERO_BC_INIT, FVM_ANDS::std2dVec_to_eigenVec(Contrail_));
         solver.updateTimestep(timestep);
-        if skipDiffusion {
+        if (skipDiffusion) {
             solver.updateDiffusion(0, 0);
         } else {
             solver.updateDiffusion(input_.horizDiff(), input_.vertiDiff());

--- a/Code.v05-00/src/FVM_ANDS/FVM_Solver.cpp
+++ b/Code.v05-00/src/FVM_ANDS/FVM_Solver.cpp
@@ -84,7 +84,7 @@ namespace FVM_ANDS{
 
         //Step 3: Implicitly solve diffusion (first to help smoothen out potential steep gradients)
 
-        if (!skipDiffusion){
+        // if (!skipDiffusion){
             advDiffSys_.updateTimestep(dt_max);
             //Build matrix takes ~40ms atm
             advDiffSys_.buildCoeffMatrix(operatorSplit);
@@ -101,7 +101,7 @@ namespace FVM_ANDS{
             // stop = std::chrono::high_resolution_clock::now();
             // duration = std::chrono::duration_cast<std::chrono::milliseconds>(stop-start);
             // std::cout << "Diffusion Solve Time: " << duration.count() << std::endl;
-        }
+        // }
 
         //Step 4: Explicitly solve advection to full timestep
 

--- a/Code.v05-00/src/YamlInputReader/YamlInputReader.cpp
+++ b/Code.v05-00/src/YamlInputReader/YamlInputReader.cpp
@@ -197,6 +197,18 @@ namespace YamlInputReader{
         input.TRANSPORT_UPDRAFT = parseBoolString(updraftSubmenu["Turn on plume updraft (T/F)"].as<string>(), "Turn on plume updraft (T/F)");
         input.TRANSPORT_UPDRAFT_TIMESCALE = parseDoubleString(updraftSubmenu["Updraft timescale [s] (double)"].as<string>(), "Updraft timescale [s] (double)");
         input.TRANSPORT_UPDRAFT_VELOCITY = parseDoubleString(updraftSubmenu["Updraft veloc. [cm/s] (double)"].as<string>(), "Updraft veloc. [cm/s] (double)");
+        
+        if (transportNode["DIFFUSION SUBMENU"]){
+            YAML::Node diffusionSubmenu = transportNode["DIFFUSION SUBMENU"];
+            input.TRANSPORT_DISABLE_DIFFUSION_AFTER_TIME = parseBoolString(diffusionSubmenu["Disable diffusion after specified time (T/F)"].as<string>(), "Disable diffusion after specified time (T/F)");
+            input.TRANSPORT_DISABLE_DIFFUSION_TIME = parseDoubleString(diffusionSubmenu["Time at which diffusion is disabled [hr] (double)"].as<string>(), "Time at which diffusion is disabled [hr] (double)");
+            if (input.TRANSPORT_DISABLE_DIFFUSION_TIME < 0){
+                throw std::invalid_argument("Time at which diffusion is disabled (under TRANSPORT MENU) cannot be less than 0!");
+            }
+        } else {
+            input.TRANSPORT_DISABLE_DIFFUSION_AFTER_TIME = false;
+            input.TRANSPORT_DISABLE_DIFFUSION_TIME = 100.0;
+        }
     }
     void readChemMenu(OptInput& input, const YAML::Node& chemNode){
         input.CHEMISTRY_CHEMISTRY = parseBoolString(chemNode["Turn on Chemistry (T/F)"].as<string>(), "Turn on Chemistry (T/F)");

--- a/examples/issl_rhi140/input.yaml
+++ b/examples/issl_rhi140/input.yaml
@@ -102,6 +102,9 @@ TRANSPORT MENU:
   # Outdated, not used (was used by spectral solver)
   Fill Negative Values (T/F): T
   Transport Timestep [min] (double): 1
+  DIFFUSION SUBMENU:
+    Disable diffusion after specified time (T/F): T
+    Time at which diffusion is disabled [hr] (double): 1.0
   # Keep off: not sure of the effect yet + met updraft is included (if met file input)
   PLUME UPDRAFT SUBMENU:
     Turn on plume updraft (T/F): F


### PR DESCRIPTION
This pull request introduces a feature to conditionally disable diffusion in the transport model after a specified time, along with the necessary changes to integrate this functionality. The most important changes include adding a new submenu in input.yaml, implementing logic to check and apply the diffusion skip condition, and updating relevant methods to support this feature.

### Feature: Conditional Diffusion Disabling

**Configuration Updates:**
* Added `TRANSPORT_DISABLE_DIFFUSION_AFTER_TIME` and `TRANSPORT_DISABLE_DIFFUSION_TIME` fields to the `OptInput` structure to enable and configure the diffusion disabling feature (`Code.v05-00/include/Core/Input_Mod.hpp`).
* Updated the YAML input reader to parse the new diffusion-related fields under a "DIFFUSION SUBMENU" section, with validation for invalid values (`Code.v05-00/src/YamlInputReader/YamlInputReader.cpp`).
* Added an example configuration for the diffusion submenu in the `input.yaml` file (`examples/issl_rhi140/input.yaml`).

**Logic Implementation:**
* Introduced a new method `checkDiffusionSkip` in `LAGRIDPlumeModel` to determine whether diffusion should be skipped based on the current simulation time and the configured threshold (`Code.v05-00/src/Core/LAGRIDPlumeModel.cpp`).
* Incorporated the `checkDiffusionSkip` logic in the `runTransport` method to conditionally skip updating diffusion vectors (`Code.v05-00/src/Core/LAGRIDPlumeModel.cpp`).

**Method Updates:**
* Modified `operatorSplitSolve` and `operatorSplitSolve2DVec` methods in `FVM_Solver` to accept a `skipDiffusion` parameter and skip the diffusion step if applicable (`Code.v05-00/include/FVM_ANDS/FVM_Solver.hpp`, `Code.v05-00/src/FVM_ANDS/FVM_Solver.cpp`). [[1]](diffhunk://#diff-af97995213cac9f25b74f65ec1315c6f409da4e7314ebcd1ce8d5988d50caf32L15-R16) [[2]](diffhunk://#diff-cb436f239e179da27f2100ad317d2bb11762c9966ab1f5e8c1a03d2e7c43ddc9L58-R58) [[3]](diffhunk://#diff-cb436f239e179da27f2100ad317d2bb11762c9966ab1f5e8c1a03d2e7c43ddc9R86-R87) [[4]](diffhunk://#diff-cb436f239e179da27f2100ad317d2bb11762c9966ab1f5e8c1a03d2e7c43ddc9L121-R124) [[5]](diffhunk://#diff-cb436f239e179da27f2100ad317d2bb11762c9966ab1f5e8c1a03d2e7c43ddc9L132-R135)
* Updated calls to `operatorSplitSolve2DVec` in `runTransport` to pass the `skipDiffusion` flag for ice aerosol, H2O, and contrail transport calculations (`Code.v05-00/src/Core/LAGRIDPlumeModel.cpp`). [[1]](diffhunk://#diff-54366a3b2927da8d01501a029212da97c518e9fe1d08173014f3c35019aa175bL411-R429) [[2]](diffhunk://#diff-54366a3b2927da8d01501a029212da97c518e9fe1d08173014f3c35019aa175bL434-R452) [[3]](diffhunk://#diff-54366a3b2927da8d01501a029212da97c518e9fe1d08173014f3c35019aa175bL450-R468)


**PR STATUS**
The PR is being tested. Performance will be evaluated against the unmodified version.