### PR TITLE
Fix #63 SO2 to SO4 input is now used properly in EPM

### DIFF
--- a/Code.v05-00/include/Core/Emission.hpp
+++ b/Code.v05-00/include/Core/Emission.hpp
@@ -23,7 +23,7 @@ class Emission
     public:
 
         Emission( );
-        Emission( const Engine &engine, const Fuel &fuel );
+        Emission( const Engine &engine, const Fuel &fuel, const double SO2ToSO4Ratio);
         Emission( const Emission &e );
         ~Emission( );
         void Populate_withEngine( const Engine &engine );
@@ -47,6 +47,7 @@ class Emission
         double getALD2( ) const;
         double getGLYX( ) const;
         double getMGLY( ) const;
+        double getSO2toSO4( ) const;
         double getSoot( ) const;
         double getSootRad( ) const;
         std::string getEngineName( ) const;
@@ -77,6 +78,9 @@ class Emission
         /* BC */
         double Soot; /* [g/kg fuel] */
         double SootRad;  /* [m] */
+
+        /* Conversion ratio */
+        double SO2toSO4; /* unitless in [0-1] */
 
         std::string engineName;
         std::string fuelChem;

--- a/Code.v05-00/include/Core/Parameters.hpp
+++ b/Code.v05-00/include/Core/Parameters.hpp
@@ -75,6 +75,5 @@
 #define VORTEX_SINKING        1           /* Consider vortex sinking? */
 #define EPM_RTOLS             1.00E-05    /* Relative tolerances in EPM */
 #define EPM_ATOLS             1.00E-07    /* Absolute tolerances in EPM */
-#define SO2TOSO4              0.005       /* Percent conversion from SO2 to SO4 */
 
 #endif /* PARAMETERS_H_INCLUDED */

--- a/Code.v05-00/src/Core/Emission.cpp
+++ b/Code.v05-00/src/Core/Emission.cpp
@@ -28,6 +28,8 @@ Emission::Emission( )
     SO2 = 0.0;
     CO  = 0.0;
     HC  = 0.0;
+
+    SO2toSO4 = 0.0;
     
     /* HC splitting */
     CH4  = 0.268248 * HC;
@@ -41,7 +43,7 @@ Emission::Emission( )
 
 } /* End of Emission::Emission */
 
-Emission::Emission( const Engine &engine, const Fuel &fuel )
+Emission::Emission( const Engine &engine, const Fuel &fuel, const double SO2ToSO4Ratio )
 {
 
     /* Constructor */
@@ -100,6 +102,8 @@ Emission::Emission( const Engine &engine, const Fuel &fuel )
         SootRad = 1.0E-09;
     }
 
+    SO2toSO4 = SO2ToSO4Ratio;
+
     engineName = engine.getName();
     fuelChem   = fuel.getChemFormula();
 
@@ -132,6 +136,8 @@ Emission::Emission( const Emission &e )
 
     Soot = e.Soot;
     SootRad = e.SootRad;
+
+    SO2toSO4 = e.SO2toSO4;
 
     engineName = e.engineName;
     fuelChem = e.fuelChem;
@@ -354,6 +360,13 @@ double Emission::getMGLY( ) const
     return MGLY;
 
 } /* End of Emission::getMGLY */
+
+double Emission::getSO2toSO4( ) const
+{
+
+    return SO2toSO4;
+    
+} /* End of Emission::getSO2toSO4 */
 
 double Emission::getSoot( ) const
 {

--- a/Code.v05-00/src/Core/LAGRIDPlumeModel.cpp
+++ b/Code.v05-00/src/Core/LAGRIDPlumeModel.cpp
@@ -30,7 +30,7 @@ LAGRIDPlumeModel::LAGRIDPlumeModel( const OptInput &optInput, const Input &input
     /* Multiply by 500 since it gets multiplied by 1/500 within the Emission object ... */ 
     jetA_.setFSC( input.EI_SO2() * 500.0 );
 
-    EI_ = Emission( aircraft_.engine(), jetA_ );
+    EI_ = Emission( aircraft_.engine(), jetA_, input.EI_SO2TOSO4());
 
     timestepVars_.setTimeArray(PlumeModelUtils::BuildTime ( timestepVars_.tInitial_s, timestepVars_.tFinal_s, timestepVars_.dt ));
 

--- a/Code.v05-00/src/Core/Structure.cpp
+++ b/Code.v05-00/src/Core/Structure.cpp
@@ -554,7 +554,7 @@ void Solution::addEmission( const Emission &EI, const Aircraft &AC,        \
     if ( !set2Saturation ) {
         E_H2O  = EI.getH2O()  / ( MW_H2O  * 1.0E+03 ) * fuelPerDist * physConst::Na;
     }
-    E_SO2  = ( 1.0 - SO2TOSO4 ) * \
+    E_SO2  = ( 1.0 - EI.getSO2toSO4() ) * \
              EI.getSO2()  / ( MW_SO2  * 1.0E+03 ) * fuelPerDist * physConst::Na;
 
     // E_Soot = EI.getSoot() / ( 4.0 / 3.0 * physConst::PI * physConst::RHO_SOOT * 1.00E+03 * rad * rad * rad ) * fuelPerDist;

--- a/Code.v05-00/src/EPM/Integrate.cpp
+++ b/Code.v05-00/src/EPM/Integrate.cpp
@@ -177,10 +177,8 @@ namespace EPM
 
         varArray[ind_H2O] = varArray[ind_H2O] / n_air_eng ;
 
-        /* Fixed SO2 */
-        // varArray[ind_SO4] += SO2TOSO4 * 0.8 / ( MW_H2SO4  * 1.0E+03 ) * AC.FuelFlow() / double(AC.EngNumber()) / AC.VFlight() * physConst::Na / Ab0 * 1.00E-06;
         /* Variable SO2 */
-        varArray[ind_SO4] += SO2TOSO4 * EI.getSO2() / ( MW_H2SO4  * 1.0E+03 ) * AC.FuelFlow() / double(AC.EngNumber()) / AC.VFlight() * physConst::Na / Ab0 * 1.00E-06;
+        varArray[ind_SO4] += EI.getSO2toSO4() * EI.getSO2() / ( MW_H2SO4  * 1.0E+03 ) * AC.FuelFlow() / double(AC.EngNumber()) / AC.VFlight() * physConst::Na / Ab0 * 1.00E-06;
         varArray[ind_SO4] = varArray[ind_SO4] / n_air_eng;
 
         double varSoot = Soot_amb + EI.getSoot() / ( 4.0 / double(3.0) * physConst::PI * physConst::RHO_SOOT * 1.00E+03 * EI.getSootRad() * EI.getSootRad() * EI.getSootRad() ) * AC.FuelFlow() / double(AC.EngNumber()) / AC.VFlight() / Ab0 * 1.00E-06 ; /* [ #/cm^3 ] */


### PR DESCRIPTION
Fixes the bug in #63 by adding a `SO2toSO4` attribute to the `Emission` object to store the ratio of SO2 to SO4 conversion provided by the user in the `input.yaml`.
The correct ratio now gets called in `Integrate.cpp` and `Structure.cpp` for chemistry calculations.