### PR TITLE
Manage OpenSSL dependency with vcpkg

### DIFF
--- a/Code.v05-00/CMakeLists.txt
+++ b/Code.v05-00/CMakeLists.txt
@@ -95,13 +95,13 @@ target_link_libraries(${PROJECT_NAME} PRIVATE netCDF::netcdf netCDF::netcdf-cxx4
 find_package(yaml-cpp CONFIG REQUIRED)
 target_link_libraries(${PROJECT_NAME} PRIVATE yaml-cpp::yaml-cpp)
 
+find_package(OpenSSL REQUIRED)
+target_link_libraries(${PROJECT_NAME} PRIVATE OpenSSL::SSL OpenSSL::Crypto)
+
 # Other dependencies:
 
 find_package(OpenMP REQUIRED)
 target_link_libraries(${PROJECT_NAME} PRIVATE OpenMP::OpenMP_CXX)
-
-find_package(OpenSSL REQUIRED)
-target_link_libraries(${PROJECT_NAME} PRIVATE OpenSSL::Crypto OpenSSL::SSL crypto ssl)
 
 # This ensures the header files of the necessary libraries are included
 # SYSTEM flag silences the compiler warnings from external dependencies 

--- a/Code.v05-00/tests/CMakeLists.txt
+++ b/Code.v05-00/tests/CMakeLists.txt
@@ -20,7 +20,7 @@ target_link_libraries(unittest  Catch2::Catch2WithMain Util AIM EPM YamlInputRea
 catch_discover_tests(unittest)
 
 add_executable(test_solver test_adv_diff_solver.cpp)
-target_link_libraries(test_solver  Catch2::Catch2WithMain FVM_ANDS Core LAGRID crypto ssl)
+target_link_libraries(test_solver  Catch2::Catch2WithMain FVM_ANDS Core LAGRID OpenSSL::SSL OpenSSL::Crypto)
 catch_discover_tests(test_solver)
 
 add_executable(test_LAGRID test_LAGRID.cpp)

--- a/Code.v05-00/vcpkg.json
+++ b/Code.v05-00/vcpkg.json
@@ -9,6 +9,7 @@
     "fmt",
     "fftw3",
     "netcdf-cxx4",
+    "openssl",
     "yaml-cpp"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ These are all managed using the `vcpkg` tool (see below) so do not need to be in
 - Catch2
 - FFTW3
 - OpenMP
+- OpenSSL
 - Boost libraries
 - yaml-cpp
 - Eigen3


### PR DESCRIPTION
A report from @lrobion showed that I hadn't got all the vcpkg dependencies quite right. This PR should fix that.