### PR TITLE
OpenSSL dependency fix

### DIFF
--- a/Code.v05-00/vcpkg.json
+++ b/Code.v05-00/vcpkg.json
@@ -9,7 +9,8 @@
     "fmt",
     "fftw3",
     "netcdf-cxx4",
-    "openssl",
+    {"name": "openssl", "version>=": "3.4.0"},
+    "curl",
     "yaml-cpp"
   ]
 }


### PR DESCRIPTION
Fixes #72 by constraining the OpenSSL version as suggested by @sdeastham.