### PR TITLE
Fix initialization from EPM output to scale correctly

### DIFF
--- a/Code.v05-00/src/Core/LAGRIDPlumeModel.cpp
+++ b/Code.v05-00/src/Core/LAGRIDPlumeModel.cpp
@@ -217,25 +217,11 @@ std::variant<EPM::Output, SimStatus> LAGRIDPlumeModel::runEPM() {
     EPM::Output &epmOutput = std::get<EPM::Output>(epmResult);
     epmOutput.write(optInput_.SIMULATION_OUTPUT_FOLDER + "/epm-output.nc");
 
-    /* Compute initial plume area and scale initial ice aerosol properties based
-    * on number engines. Note that EPM results are for ONLY ONE ENGINE. If 2
-    * engines, we assume that after 3 mins, the two plumes haven't fully mixed
-    * yet and result in a total area of 2 * the area computed for one engine If 3
-    * or more engines, we assume that the plumes originating from the same wing
-    * have mixed. */
-
-    epmOutput.area *= 2.0;
-    if (aircraft_.EngNumber() != 2) {
-        // Scale densities by this factor to account for the plume size
-        // already doubling.
-        epmOutput.iceDensity *= aircraft_.EngNumber() / 2.0;
-        epmOutput.sootDensity *= aircraft_.EngNumber() / 2.0;
-
-        // EPM only runs for one engine, so scale aerosol pdfs by engine
-        // number.
-        epmOutput.SO4Aer.scalePdf(aircraft_.EngNumber());
-        epmOutput.IceAer.scalePdf(aircraft_.EngNumber());
-    }
+    /* The output area from the EPM is principally used just to scale from
+    number densities (eg #/cm3) to totals (eg #/m). Increasing the area
+    is the easiest way to represent the fact that multiple engines are in
+    use - recalling that the EPM is only actually run for one engine. */
+    epmOutput.area *= aircraft_.EngNumber();
 
     // Run vortex sink parameterization
     const double iceNumFrac = aircraft_.VortexLosses(

--- a/Code.v05-00/src/EPM/Models/Original/Integrate.cpp
+++ b/Code.v05-00/src/EPM/Models/Original/Integrate.cpp
@@ -281,6 +281,7 @@ namespace EPM::Models
         double SO4l_3mins = 0;
         double SO4g_3mins = 0;
         double Tracer_3mins = 0;
+        double n_air_3mins = 0;
         AIM::Aerosol pSO4pdf_3mins( nPDF_SO4 );
 
         iTime = 0;
@@ -348,6 +349,7 @@ namespace EPM::Models
             if ( iTime == iTime_3mins ) {
                 PartRad_3mins  = observer.m_states[observer.m_states.size()-1][EPM_ind_ParR];
                 PartDens_3mins = observer.m_states[observer.m_states.size()-1][EPM_ind_Part] * n_air;
+                n_air_3mins = n_air;
                 H2OMol_3mins   = observer.m_states[observer.m_states.size()-1][EPM_ind_H2O]; //* observer.m_states[observer.m_states.size()-1][EPM_ind_P] / (kB * observer.m_states[observer.m_states.size()-1][EPM_ind_T]) * 1.0E-06;
                 Tracer_3mins   = observer.m_states[observer.m_states.size()-1][EPM_ind_Trac];
 //                SO4pdf_3mins   = nPDF_SO4;
@@ -401,7 +403,7 @@ namespace EPM::Models
         IceAer = solidAer;
 
         /* Compute plume area */
-        Area = Ab0 / Tracer_3mins;
+        Area = Ab0 * n_air_eng / (n_air_3mins * Tracer_3mins);
 
 //        std::cout << " Soot end: " << ( varSoot - Soot_amb  ) * 1E6 * Ab0 << " [#/m]\n";
 //        std::cout << " Soot end: " << ( Soot_den - Soot_amb ) * 1E6 * Ab0 / Tracer_3mins << "[#/m]\n";


### PR DESCRIPTION
This PR fixes issues #76 and #38. Scaling of the EPM output with engine number is now a straight-forward multiplication. Meanwhile the area calculated at the EPM exit is now scaled to account for cooling of the plume (by $n_0/n_1$, where $n_0$ is the initial air number density at the engine exit plane and $n_1$ is the air number density after three minutes). This ensures that the total number of emitted soot particles matches the expected number. Initial testing shows a reduction in initial ice particle number per meter by a factor of ~2.5x, so this is expected to significantly affect model results.