### PR TITLE
Remove initial water saturation check

### DIFF
--- a/Code.v05-00/src/EPM/Models/Original/Integrate.cpp
+++ b/Code.v05-00/src/EPM/Models/Original/Integrate.cpp
@@ -367,13 +367,7 @@ namespace EPM::Models
             observer.print2File();
         }
         /* Output variables */
-        /* Check if contrail is water supersaturated at some point during formation */
-        if ( !simVars_.CHEMISTRY && !observer.checkwatersat() ) {
-            std::cout << "EndSim: Never reaches water saturation... ending simulation" << std::endl;
-            //exit(0);
-            return SimStatus::NoWaterSaturation;
-        }
-
+        
         /* Persistent contrail */
         if ( relHumidity_i_Final >= 1.0 ) {
 


### PR DESCRIPTION
_This PR was closed because it was based on wrong logic (the text in strikethrough below), which was highlighted in the comments by @chinahg and @askprash._

This pull request removes an early exit condition in the simulation logic for contrail formation, specifically the check for water supersaturation. This means the simulation will continue even if water saturation is never reached, instead of ending early.

~~As stated in Issue https://github.com/MIT-LAE/APCEMM/issues/79, this check is not representative of contrail formation because the ice saturation vapor pressure is lower than the water saturation vapor pressure:~~ 

<img width="400" height="300" alt="Image" src="https://github.com/user-attachments/assets/77580bde-c271-4fd8-a08b-c1016842081f" />

This means that ice can form before water droplets. Therefore, the [remaining check for ice supersaturation ](https://github.com/MIT-LAE/APCEMM/blob/dc763ec17aa8e7e7661bb0a1d5a12ba92b8f8e60/Code.v05-00/src/EPM/Models/Original/Integrate.cpp#L378) is hence the only sufficient condition for a persistent contrail to form.

This affects contrails that are in warm, barely ice-supersaturated air (e.g. 225 K at 110 % RHi).

## Simulation logic changes:

* Removed the check for water supersaturation and the corresponding early return of `SimStatus::NoWaterSaturation` in `Integrate.cpp`, allowing the simulation to proceed regardless of water saturation status.


## Results:

No checks on the standard case are necessary because the only change is the removal of a boolean exit condition in the EPM.