### PR TITLE
Enable saving of gridded PSD from yaml file

### DIFF
--- a/Code.v05-00/include/Core/Diag_Mod.hpp
+++ b/Code.v05-00/include/Core/Diag_Mod.hpp
@@ -50,14 +50,7 @@ namespace Diag {
     void add2DVar(NcFile& currFile, const Vector_2D& toSave, const vector<NcDim> dims, const string& name, const string& desc, const string& units);
     void add3DVar(NcFile& currFile, const Vector_3D& toSave, const vector<NcDim> dims, const string& name, const string& desc, const string& units);
     void replace_hhmmss(string& fileName, int hh, int mm, int ss);
-
-    namespace {
-        bool storePSD = false;
-    }
-
-    inline void set_storePSD(bool val) {
-        storePSD = val;
-    }
+    void set_storePSD(bool val);
 
 } // namespace Diag
 

--- a/Code.v05-00/include/Core/Diag_Mod.hpp
+++ b/Code.v05-00/include/Core/Diag_Mod.hpp
@@ -51,6 +51,14 @@ namespace Diag {
     void add3DVar(NcFile& currFile, const Vector_3D& toSave, const vector<NcDim> dims, const string& name, const string& desc, const string& units);
     void replace_hhmmss(string& fileName, int hh, int mm, int ss);
 
+    namespace {
+        bool storePSD = false;
+    }
+
+    inline void set_storePSD(bool val) {
+        storePSD = val;
+    }
+
 } // namespace Diag
 
 #endif /* DIAG_MOD_H_INCLUDED */

--- a/Code.v05-00/include/Core/Input_Mod.hpp
+++ b/Code.v05-00/include/Core/Input_Mod.hpp
@@ -157,6 +157,7 @@ struct OptInput
     double ADV_EP_WINGSPAN_REF;
     bool ADV_EP_N_POSTJET_OVERRIDE;
     double ADV_EP_N_POSTJET;
+    bool ADV_SAVE_PSD_GRID;
 
 };
 

--- a/Code.v05-00/src/Core/Diag_Mod.cpp
+++ b/Code.v05-00/src/Core/Diag_Mod.cpp
@@ -254,8 +254,6 @@ namespace Diag {
         add0DVar(currFile, iceAer.extinctionDepth(yCoord), tDim, "depth", "Contrail Extinction-Defined Depth", "m");
         add0DVar(currFile, iceAer.intYOD(dx_vec, dy_vec), tDim, "intOD", "Integrated Vertical Optical Depth", "m");
 
-        // Set this to true to store out the full PSD. Warning - this is a lot of data and takes time to save out!
-        bool storePSD = false;
         if (storePSD)
         {
             add3DVar(currFile, iceAer.Number(), xycDims, "n_aer", "Ice aerosol particle number concentration by radius", "# / cm^3");

--- a/Code.v05-00/src/Core/Diag_Mod.cpp
+++ b/Code.v05-00/src/Core/Diag_Mod.cpp
@@ -23,6 +23,14 @@
 
 namespace Diag {
 
+    namespace {
+        bool storePSD = false;
+    }
+
+    void set_storePSD(bool val){
+        storePSD = val;
+    }
+
     static const NcType& varDataType = ncFloat;
 
     void replace_hhmmss(string& fileName, int hh, int mm, int ss) {

--- a/Code.v05-00/src/Main.cpp
+++ b/Code.v05-00/src/Main.cpp
@@ -31,6 +31,7 @@
 #include "Core/Input.hpp"
 #include "Core/LAGRIDPlumeModel.hpp"
 #include "Core/Status.hpp"
+#include "Core/Diag_Mod.hpp"
 #include "Util/MC_Rand.hpp"
 
 void CreateREADME( const std::string folder, const std::string fileName, \
@@ -94,6 +95,10 @@ int main( int argc, char* argv[])
         }
         
         YamlInputReader::readYamlInputFiles( Input_Opt, INPUT_FILE_PATHS );
+
+        if (Input_Opt.ADV_SAVE_PSD_GRID){
+            Diag::set_storePSD(true);
+        }
     }  /* master CPU */
 
     // Set the seed once at the top-level

--- a/Code.v05-00/src/YamlInputReader/YamlInputReader.cpp
+++ b/Code.v05-00/src/YamlInputReader/YamlInputReader.cpp
@@ -333,6 +333,12 @@ namespace YamlInputReader{
             input.ADV_EP_N_POSTJET_OVERRIDE = false;
             input.ADV_EP_N_POSTJET = 0;
         }
+
+        if (advancedNode["Save gridded particle size distribution (T/F)"]){
+            input.ADV_SAVE_PSD_GRID = parseBoolString(advancedNode["Save gridded particle size distribution (T/F)"].as<string>(), "Save gridded particle size distribution (T/F)");
+        } else {
+            input.ADV_SAVE_PSD_GRID = false;
+        }
     }
 
     vector<std::unordered_map<string, double>> generateCasesHelper(vector<std::unordered_map<string, double>>& allCases, const vector<std::pair<string, Vector_1D>>& params, const std::size_t row){

--- a/examples/issl_rhi140/input.yaml
+++ b/examples/issl_rhi140/input.yaml
@@ -190,6 +190,7 @@ DIAGNOSTIC MENU:
 # Sometimes you have to change YLIM_DOWN here if the supersaturated layer is very thick
 # because YLIM_DOWN must be larger than the layer thickness.
 ADVANCED OPTIONS MENU:
+  Save gridded particle size distribution (T/F): F # WARNING: If T, it can generate very large output files and slow down the simulation
   # Domain is defined as: X [-XLIM_LEFT, XLIM_RIGHT], Y [-YLIM_DOWN, YLIM_UP]
   GRID SUBMENU:
     NX (positive int): 200


### PR DESCRIPTION
Adding to https://github.com/MIT-LAE/APCEMM/pull/82, this PR allows the PSD output bool to be toggled from the Advanced Menu of the input.yaml through the use of:

`Save gridded particle size distribution (T/F):  T`

This implementation is fully retrocompatible.
