### PR TITLE
Fix units mismatch when calculating water mass

### DIFF
--- a/Code.v05-00/src/Core/LAGRIDPlumeModel.cpp
+++ b/Code.v05-00/src/Core/LAGRIDPlumeModel.cpp
@@ -327,7 +327,6 @@ void LAGRIDPlumeModel::initH2O() {
 
     double mass_WV = WV_exhaust_ / 1e3 - icemass; // WV_exhaust converted from [g/m] -> [kg/m]
     double E_H2O = mass_WV / (MW_H2O) * Na;
-    std::cout << "Emitted water - ice water: " << mass_WV << " [kg/m]" << std::endl;
 
     // Spread the emitted water evenly over the cells that contain ice crystals
     auto localPlumeEmission = [&](std::size_t j, std::size_t i) -> double {

--- a/Code.v05-00/src/Core/LAGRIDPlumeModel.cpp
+++ b/Code.v05-00/src/Core/LAGRIDPlumeModel.cpp
@@ -325,8 +325,8 @@ void LAGRIDPlumeModel::initH2O() {
     auto areas = VectorUtils::cellAreas(xEdges_, yEdges_);
     const double icemass = iceAerosol_.TotalIceMass_sum(areas);
 
-    double mass_WV = WV_exhaust_ - icemass;
-    double E_H2O = mass_WV / (MW_H2O * 1e3) * Na;
+    double mass_WV = WV_exhaust_ / 1e3 - icemass; // WV_exhaust converted from [g/m] -> [kg/m]
+    double E_H2O = mass_WV / (MW_H2O) * Na;
 
     // Spread the emitted water evenly over the cells that contain ice crystals
     auto localPlumeEmission = [&](std::size_t j, std::size_t i) -> double {

--- a/Code.v05-00/src/Core/LAGRIDPlumeModel.cpp
+++ b/Code.v05-00/src/Core/LAGRIDPlumeModel.cpp
@@ -327,6 +327,7 @@ void LAGRIDPlumeModel::initH2O() {
 
     double mass_WV = WV_exhaust_ / 1e3 - icemass; // WV_exhaust converted from [g/m] -> [kg/m]
     double E_H2O = mass_WV / (MW_H2O) * Na;
+    std::cout << "Emitted water - ice water: " << mass_WV << " [kg/m]" << std::endl;
 
     // Spread the emitted water evenly over the cells that contain ice crystals
     auto localPlumeEmission = [&](std::size_t j, std::size_t i) -> double {


### PR DESCRIPTION
## The problem
(Copy/pasted from Issue https://github.com/MIT-LAE/APCEMM/issues/87):
When calculating the ice mass uptake from the environment in
https://github.com/MIT-LAE/APCEMM/blob/95ab9768eb3aaa4fedf112d58dcd7c41a134c344/Code.v05-00/src/Core/LAGRIDPlumeModel.cpp#L326-L329

`WV_exhaust_` is in g but it is combined with `icemass` which is in kg and then divided by 1e3 (which assumes grams). 

- `WV_exhaust_` is calculated with `EI.getH2O()` (see [LAGRIDPlumeModel.cpp](https://github.com/MIT-LAE/APCEMM/blob/95ab9768eb3aaa4fedf112d58dcd7c41a134c344/Code.v05-00/src/Core/LAGRIDPlumeModel.cpp#L61)), which returns the water emissions index in g/kg of fuel (see [Emission.cpp](https://github.com/MIT-LAE/APCEMM/blob/main/Code.v05-00/src/Core/Emission.cpp))
- `icemass` is in kg because it is calculated from `IWC()` (see [Aerosol.cpp](https://github.com/MIT-LAE/APCEMM/blob/95ab9768eb3aaa4fedf112d58dcd7c41a134c344/Code.v05-00/src/AIM/Aerosol.cpp#L1308-L1327)), which is in kg/m3 (see [Aerosol.cpp](https://github.com/MIT-LAE/APCEMM/blob/95ab9768eb3aaa4fedf112d58dcd7c41a134c344/Code.v05-00/src/AIM/Aerosol.cpp#L1344))

This leads to `WV_exhaust_` being effectively 1e3 higher than the `icemass`, guaranteeing that water is added to (not subtracted from) the environment. 

Effectively, the bugfix from PR https://github.com/MIT-LAE/APCEMM/pull/59 , which attempted to solve the issue of water being double-counted (see Issue https://github.com/MIT-LAE/APCEMM/issues/39) resulted in tiny changes to the contrail properties because the bugged equations reduce to the ones prior to the bugfix.



## The fix
This PR solves the units mismatch by dividing `WV_exhaust_` by 1e3 instead of the whole expression, solving the units mismatch. The other uses of  `WV_exhaust_` have been checked and verified to be correct.

## Effects on initialisation

For cases in which APCEMM controls the early plume, the bugfix barely makes a difference to initialisation conditions:
<img width="696" height="314" alt="nocustom_distribution" src="https://github.com/user-attachments/assets/9ea06e52-8716-483c-849b-d9f82b70ed10" />

For cases in which I hijacked the early plume, the bugfix works as intended:
<img width="696" height="314" alt="custom distribution" src="https://github.com/user-attachments/assets/f44ea26f-8049-49ed-a14b-bffdf758008f" />

See Issue https://github.com/MIT-LAE/APCEMM/issues/88 for more details.

## (For interest only) Effect on time evolution (hijacked early plume only)
<img width="696" height="314" alt="effectoftimeevolv" src="https://github.com/user-attachments/assets/66d8bd2a-a990-4ce2-8330-784ee8af81f1" />

As it can be seen, the ice number decreases sooner in the time evolution, leading to a reduction in the peak ice mass.


## Outcomes
The units bug has been fixed, but a new issue has been identified with the vortex formulation. See Issue https://github.com/MIT-LAE/APCEMM/issues/88 for more details.
