### PR TITLE
Faster transport

### DIFF
--- a/Code.v05-00/CMakeLists.txt
+++ b/Code.v05-00/CMakeLists.txt
@@ -6,6 +6,7 @@ set(CMAKE_TOOLCHAIN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/submodules/vcpkg/scripts/b
 project(APCEMM)
 
 # Options
+option(ENABLE_TIMING "Enable detailed timing instrumentation" OFF)
 option(DEBUG "Enable debug mode" OFF)
 SET(RINGS 0)
 SET(OMP 1)

--- a/Code.v05-00/include/APCEMM.h.in
+++ b/Code.v05-00/include/APCEMM.h.in
@@ -1,5 +1,6 @@
 /* Template for CMake to generate an APCEMM.h with appropriate preprocessor definitions
 given boolean values of the parameters during CMake compilation. */
+#cmakedefine ENABLE_TIMING
 #cmakedefine DEBUG
 #cmakedefine RINGS
 #cmakedefine OMP

--- a/Code.v05-00/include/FVM_ANDS/AdvDiffSystem.hpp
+++ b/Code.v05-00/include/FVM_ANDS/AdvDiffSystem.hpp
@@ -62,6 +62,10 @@ namespace FVM_ANDS{
                 Dh_vec_ = std2dVec_to_eigenVec(Dh);
                 Dv_vec_ = std2dVec_to_eigenVec(Dv);
             }
+            inline void updateDiffusion(const Eigen::VectorXd& Dh, const Eigen::VectorXd& Dv){
+                Dh_vec_ = Dh;
+                Dv_vec_ = Dv;
+            }
             inline void updateAdvection(double u, double v, double shear){
                 u_double_ = u;
                 v_double_ = v;

--- a/Code.v05-00/include/FVM_ANDS/AdvDiffSystem.hpp
+++ b/Code.v05-00/include/FVM_ANDS/AdvDiffSystem.hpp
@@ -43,6 +43,10 @@ namespace FVM_ANDS{
             inline const Eigen::VectorXd& phi() const { return phi_; }
             inline const std::vector<std::unique_ptr<Point>>& points() const { return points_; }
             inline const Eigen::SparseMatrix<double, Eigen::RowMajor>& getCoefMatrix() const { return totalCoefMatrix_; }
+            inline void setCoefMatrix(const Eigen::SparseMatrix<double, Eigen::RowMajor>& matrix) {
+                // If we reuse an existing matrix, we can set it directly
+                totalCoefMatrix_ = matrix; 
+            }
             inline void updatePhi(const Eigen::VectorXd& phi_new){ 
                 //Need to resize to account for grid changing in size.
                 phi_.resize(nx_ * ny_ + 2*nx_ + 2*ny_);

--- a/Code.v05-00/include/FVM_ANDS/AdvDiffSystem.hpp
+++ b/Code.v05-00/include/FVM_ANDS/AdvDiffSystem.hpp
@@ -38,14 +38,21 @@ namespace FVM_ANDS{
             Eigen::VectorXd forwardEulerAdvection(bool operatorSplit = false, bool parallelAdvection = false) const noexcept;
             // Breakup the implementation of sor_solve to allow for easy testing by inputing an arbitrary linear system to solve:
             // Implementation is moved outside of the class, and make class method to be used in code
-            void sor_solve(double omega = 1.0, double threshold = 1e-3, int n_iters = 3){ FVM_ANDS::sor_solve(totalCoefMatrix_, rhs_, phi_, omega, threshold, n_iters); };
+            void sor_solve(double omega = 1.0, double threshold = 1e-3, int n_iters = 3){ 
+                FVM_ANDS::sor_solve(getCoefMatrix(), rhs_, phi_, omega, threshold, n_iters); 
+            };
             inline const Eigen::VectorXd& getRHS() const { return rhs_; }
             inline const Eigen::VectorXd& phi() const { return phi_; }
             inline const std::vector<std::unique_ptr<Point>>& points() const { return points_; }
-            inline const Eigen::SparseMatrix<double, Eigen::RowMajor>& getCoefMatrix() const { return totalCoefMatrix_; }
-            inline void setCoefMatrix(const Eigen::SparseMatrix<double, Eigen::RowMajor>& matrix) {
-                // If we reuse an existing matrix, we can set it directly
-                totalCoefMatrix_ = matrix; 
+            inline const Eigen::SparseMatrix<double, Eigen::RowMajor>& getCoefMatrix() const { 
+                return use_prebuilt_matrix_ ? *prebuilt_matrix_ : totalCoefMatrix_; 
+            }
+            inline std::shared_ptr<const Eigen::SparseMatrix<double, Eigen::RowMajor>> getCoefMatrixPtr() {
+                return std::make_shared<const Eigen::SparseMatrix<double, Eigen::RowMajor>>(totalCoefMatrix_);
+            }
+            inline void setCoefMatrix(std::shared_ptr<const Eigen::SparseMatrix<double, Eigen::RowMajor>> matrix) {
+                prebuilt_matrix_ = matrix;
+                use_prebuilt_matrix_ = true;
             }
             inline void updatePhi(const Eigen::VectorXd& phi_new){ 
                 //Need to resize to account for grid changing in size.
@@ -150,6 +157,8 @@ namespace FVM_ANDS{
             Vector_1D bcVals_bot_;
             std::vector<std::unique_ptr<Point>> points_;
             Eigen::SparseMatrix<double, Eigen::RowMajor> totalCoefMatrix_;
+            std::shared_ptr<const Eigen::SparseMatrix<double, Eigen::RowMajor>> prebuilt_matrix_;
+            bool use_prebuilt_matrix_ = false;
             Eigen::VectorXd rhs_;
             Eigen::VectorXd phi_;
             Eigen::VectorXd source_;

--- a/Code.v05-00/include/FVM_ANDS/AdvDiffSystem.hpp
+++ b/Code.v05-00/include/FVM_ANDS/AdvDiffSystem.hpp
@@ -45,14 +45,22 @@ namespace FVM_ANDS{
             inline const Eigen::VectorXd& phi() const { return phi_; }
             inline const std::vector<std::unique_ptr<Point>>& points() const { return points_; }
             inline const Eigen::SparseMatrix<double, Eigen::RowMajor>& getCoefMatrix() const { 
-                return use_prebuilt_matrix_ ? *prebuilt_matrix_ : totalCoefMatrix_; 
+                // If using prebuilt matrix, this instance of AdvDiffSystem does not have its own
+                // totalCoefMatrix_, instead it holds a pointer to a shared matrix held in another AdvDiffSystem
+                // Getter abstracts that away to have one access pattern
+                return use_shared_totalCoefMatrix_ ? *shared_totalCoefMatrixPtr_ : totalCoefMatrix_; 
             }
             inline std::shared_ptr<const Eigen::SparseMatrix<double, Eigen::RowMajor>> getCoefMatrixPtr() {
+                // Only used by the AdvDiffSystem instance that actually computed the matrix to make it available to
+                // other instances without copying the full matrix. Other instances will just hold a copy of
+                // this shared pointer
                 return std::make_shared<const Eigen::SparseMatrix<double, Eigen::RowMajor>>(totalCoefMatrix_);
             }
-            inline void setCoefMatrix(std::shared_ptr<const Eigen::SparseMatrix<double, Eigen::RowMajor>> matrix) {
-                prebuilt_matrix_ = matrix;
-                use_prebuilt_matrix_ = true;
+            inline void setCoefMatrix(std::shared_ptr<const Eigen::SparseMatrix<double, Eigen::RowMajor>> matrixPtr) {
+                // Only used by AdvDiffSystem instances that did not compute the matrix. This sets the shared pointer
+                // to the matrix that is held in another instance
+                shared_totalCoefMatrixPtr_ = matrixPtr;
+                use_shared_totalCoefMatrix_ = true;
             }
             inline void updatePhi(const Eigen::VectorXd& phi_new){ 
                 //Need to resize to account for grid changing in size.
@@ -157,8 +165,8 @@ namespace FVM_ANDS{
             Vector_1D bcVals_bot_;
             std::vector<std::unique_ptr<Point>> points_;
             Eigen::SparseMatrix<double, Eigen::RowMajor> totalCoefMatrix_;
-            std::shared_ptr<const Eigen::SparseMatrix<double, Eigen::RowMajor>> prebuilt_matrix_;
-            bool use_prebuilt_matrix_ = false;
+            std::shared_ptr<const Eigen::SparseMatrix<double, Eigen::RowMajor>> shared_totalCoefMatrixPtr_;
+            bool use_shared_totalCoefMatrix_ = false;
             Eigen::VectorXd rhs_;
             Eigen::VectorXd phi_;
             Eigen::VectorXd source_;

--- a/Code.v05-00/include/FVM_ANDS/FVM_Solver.hpp
+++ b/Code.v05-00/include/FVM_ANDS/FVM_Solver.hpp
@@ -20,11 +20,6 @@ namespace FVM_ANDS{
             void buildCoeffMatrix(bool operatorSplit = false){
                 advDiffSys_.buildCoeffMatrix(operatorSplit);
             }
-
-            inline void setPrebuiltMatrix(const Eigen::SparseMatrix<double, Eigen::RowMajor>& matrix) {
-                advDiffSys_.setCoefMatrix(matrix);
-                matrix_prebuilt_ = true;
-            }
             inline void updateTimestep(double dt){
                 advDiffSys_.updateTimestep(dt);
             }
@@ -60,6 +55,13 @@ namespace FVM_ANDS{
             }
             inline const Eigen::SparseMatrix<double, Eigen::RowMajor>& coefMatrix(){
                 return advDiffSys_.getCoefMatrix();
+            }
+            inline std::shared_ptr<const Eigen::SparseMatrix<double, Eigen::RowMajor>> coefMatrixPtr(){
+                return advDiffSys_.getCoefMatrixPtr();
+            }
+            inline void setPrebuiltMatrix(std::shared_ptr<const Eigen::SparseMatrix<double, Eigen::RowMajor>> matrix) {
+                advDiffSys_.setCoefMatrix(matrix);
+                matrix_prebuilt_ = true;
             }
             inline const std::vector<std::unique_ptr<Point>>& points(){
                 return advDiffSys_.points();

--- a/Code.v05-00/include/FVM_ANDS/FVM_Solver.hpp
+++ b/Code.v05-00/include/FVM_ANDS/FVM_Solver.hpp
@@ -29,6 +29,9 @@ namespace FVM_ANDS{
             inline void updateDiffusion(const Vector_2D& Dh, const Vector_2D& Dv){
                 advDiffSys_.updateDiffusion(Dh, Dv);
             }
+            inline void updateDiffusion(const Eigen::VectorXd& Dh, const Eigen::VectorXd& Dv){
+                advDiffSys_.updateDiffusion(Dh, Dv);
+            }
             inline void updateAdvection(double u, double v, double shear){
                 advDiffSys_.updateAdvection(u, v, shear);
             }

--- a/Code.v05-00/include/FVM_ANDS/FVM_Solver.hpp
+++ b/Code.v05-00/include/FVM_ANDS/FVM_Solver.hpp
@@ -6,7 +6,7 @@
 namespace FVM_ANDS{
     class FVM_Solver{
         public:
-            FVM_Solver(const AdvDiffParams& params, const Vector_1D xCoords, const Vector_1D yCoords, const BoundaryConditions& bc, const Eigen::VectorXd& phi_init, bool useDiagPreCond = false, int maxIters_ = 1000, double convergenceThres_ = 1e-5);
+            FVM_Solver(const AdvDiffParams& params, const Vector_1D& xCoords, const Vector_1D& yCoords, const BoundaryConditions& bc, const Eigen::VectorXd& phi_init, bool useDiagPreCond = false, int maxIters_ = 1000, double convergenceThres_ = 1e-5);
             const Eigen::VectorXd& solve();
             const Eigen::VectorXd& solve(const Eigen::VectorXd& source);
             const Eigen::VectorXd& explicitSolve();

--- a/Code.v05-00/include/FVM_ANDS/FVM_Solver.hpp
+++ b/Code.v05-00/include/FVM_ANDS/FVM_Solver.hpp
@@ -20,6 +20,11 @@ namespace FVM_ANDS{
             void buildCoeffMatrix(bool operatorSplit = false){
                 advDiffSys_.buildCoeffMatrix(operatorSplit);
             }
+
+            inline void setPrebuiltMatrix(const Eigen::SparseMatrix<double, Eigen::RowMajor>& matrix) {
+                advDiffSys_.setCoefMatrix(matrix);
+                matrix_prebuilt_ = true;
+            }
             inline void updateTimestep(double dt){
                 advDiffSys_.updateTimestep(dt);
             }
@@ -97,6 +102,7 @@ namespace FVM_ANDS{
             double convergenceThres_;
             AdvDiffSystem advDiffSys_;
             bool useDiagPreCond_;
+            bool matrix_prebuilt_ = false;
             Eigen::DiagonalMatrix<double, -1> diagPreCond;
             Eigen::DiagonalMatrix<double, -1> diagPreCond_inv;
             Eigen::BiCGSTAB<Eigen::SparseMatrix<double, Eigen::RowMajor>, Eigen::DiagonalPreconditioner<double> > solver_;

--- a/Code.v05-00/src/Core/LAGRIDPlumeModel.cpp
+++ b/Code.v05-00/src/Core/LAGRIDPlumeModel.cpp
@@ -472,16 +472,22 @@ void LAGRIDPlumeModel::runTransport(double timestep) {
     start = std::chrono::high_resolution_clock::now();
     #endif
 
+    // Convert this once for all ~38 aerosol size bins as it reused for all of them
+    // The real solution is to use Eigen::VectorXd from the start...
+    Eigen::VectorXd H2O_eigen = FVM_ANDS::std2dVec_to_eigenVec(H2O_);
+    Eigen::VectorXd diffCoeffX_eigen = FVM_ANDS::std2dVec_to_eigenVec(diffCoeffX_);
+    Eigen::VectorXd diffCoeffY_eigen = FVM_ANDS::std2dVec_to_eigenVec(diffCoeffY_);
+
     //Transport the Ice Aerosol PDF
     #pragma omp parallel for default(shared)
     for ( UInt n = 0; n < iceAerosol_.getNBin(); n++ ) {
         /* Transport particle number and volume for each bin and
             * recompute centers of each bin for each grid cell
             * accordingly */
-        FVM_ANDS::FVM_Solver solver(fvmSolverInitParams, xCoords_, yCoords_, ZERO_BC_INIT, FVM_ANDS::std2dVec_to_eigenVec(H2O_));
+        FVM_ANDS::FVM_Solver solver(fvmSolverInitParams, xCoords_, yCoords_, ZERO_BC_INIT, H2O_eigen);
         //Update solver params
         solver.updateTimestep(timestep);
-        solver.updateDiffusion(diffCoeffX_, diffCoeffY_);
+        solver.updateDiffusion(diffCoeffX_eigen, diffCoeffY_eigen);
         solver.updateAdvection(0, -vFall_[n], shear_rep_);
 
         //passing in "false" to the "parallelAdvection" param to not spawn more threads
@@ -499,7 +505,7 @@ void LAGRIDPlumeModel::runTransport(double timestep) {
     //Transport H2O
     {   
         //Dont use enhanced diffusion on the H2O (and zero settling velocity)
-        FVM_ANDS::FVM_Solver solver(fvmSolverInitParams, xCoords_, yCoords_, ZERO_BC_INIT, FVM_ANDS::std2dVec_to_eigenVec(H2O_));
+        FVM_ANDS::FVM_Solver solver(fvmSolverInitParams, xCoords_, yCoords_, ZERO_BC_INIT, H2O_eigen);
         solver.updateTimestep(timestep);
         solver.updateDiffusion(input_.horizDiff(), input_.vertiDiff());
         solver.updateAdvection(0, 0, shear_rep_);

--- a/Code.v05-00/src/Core/LAGRIDPlumeModel.cpp
+++ b/Code.v05-00/src/Core/LAGRIDPlumeModel.cpp
@@ -1,3 +1,4 @@
+#include <chrono>
 #include <filesystem>
 #include <memory>
 #include "AIM/Settling.hpp"
@@ -91,16 +92,31 @@ SimStatus LAGRIDPlumeModel::runFullModel() {
     SimStatus status = SimStatus::Incomplete;
     //Start time loop
     while ( timestepVars_.curr_Time_s < timestepVars_.tFinal_s ) {
+        #ifdef ENABLE_TIMING
+        auto timestep_start = std::chrono::high_resolution_clock::now();
+        #endif
+
         /* Print message */
         std::cout << "\n";
         std::cout << "\n - Time step: " << timestepVars_.nTime + 1 << " out of " << timestepVars_.timeArray.size();
         std::cout << "\n -> Solar time: " << std::fmod( timestepVars_.curr_Time_s/3600.0, 24.0 ) << " [hr]" << std::endl;
 
         // Run Transport
-        std::cout << "Running Transport" << std::endl;
+        std::cout << "Running Transport..." << std::endl;
         bool timeForTransport = (simVars_.TRANSPORT && (timestepVars_.nTime == 0 || timestepVars_.checkTimeForTransport()));
         if (timeForTransport) {
+
+            #ifdef ENABLE_TIMING
+            auto transport_start = std::chrono::high_resolution_clock::now();
+            #endif
+
             runTransport(timestepVars_.TRANSPORT_DT);
+
+            #ifdef ENABLE_TIMING
+            auto transport_end = std::chrono::high_resolution_clock::now();
+            auto transport_duration = std::chrono::duration_cast<std::chrono::milliseconds>(transport_end - transport_start);
+            std::cout << "  Ran transport in " << transport_duration.count() << " ms" << std::endl;
+            #endif
         }
 
         /*  With LAGRID remapping every transport timestep, it fundamentally only makes physical sense to update
@@ -117,9 +133,24 @@ SimStatus LAGRIDPlumeModel::runFullModel() {
         // Run Ice Growth
         if (simVars_.ICE_GROWTH && timestepVars_.checkTimeForIceGrowth()) {
             std::cout << "Running ice growth..." << std::endl;
+
+            #ifdef ENABLE_TIMING
+            auto icegrowth_start = std::chrono::high_resolution_clock::now();
+            #endif
+
             timestepVars_.lastTimeIceGrowth = timestepVars_.curr_Time_s + timestepVars_.dt;
             iceAerosol_.Grow( timestepVars_.ICE_GROWTH_DT, H2O_, met_.Temp(), met_.Press());
+
+            #ifdef ENABLE_TIMING
+            auto icegrowth_end = std::chrono::high_resolution_clock::now();
+            auto icegrowth_duration = std::chrono::duration_cast<std::chrono::milliseconds>(icegrowth_end - icegrowth_start);
+            std::cout << "  Ran ice growth in " << icegrowth_duration.count() << " ms" << std::endl;
+            #endif
         }
+
+        #ifdef ENABLE_TIMING
+        auto tracer_start = std::chrono::high_resolution_clock::now();
+        #endif
 
         // Update the tracer of contrail influence to include all locations where we have ice
         // Set it to 1 when there's at least 1 particle per m3 
@@ -129,6 +160,14 @@ SimStatus LAGRIDPlumeModel::runFullModel() {
                 Contrail_[j][i] = std::max(0.0,std::min(1.0,Contrail_[j][i] + number[j][i]*1.0e6));
             }
         }
+
+        #ifdef ENABLE_TIMING
+        auto tracer_end = std::chrono::high_resolution_clock::now();
+        auto tracer_duration = std::chrono::duration_cast<std::chrono::milliseconds>(tracer_end - tracer_start);
+        std::cout << "  Ran tracer update in " << tracer_duration.count() << " ms" << std::endl;
+
+        auto met_update_start = std::chrono::high_resolution_clock::now();
+        #endif
 
         // Create the mask of cells to retain, and terminate if none left
         auto dataMask = ContrailMask(0.90);
@@ -171,6 +210,15 @@ SimStatus LAGRIDPlumeModel::runFullModel() {
         // update altitudeInit_ and altitudeEdgesInit_ (pressureInit_ unchanged)
         std::cout << "Updating Met..." << std::endl;
         met_.Update( timestepVars_.TRANSPORT_DT, solarTime_h_, simTime_h_);
+
+
+        #ifdef ENABLE_TIMING
+        auto met_update_end = std::chrono::high_resolution_clock::now();
+        auto met_update_duration = std::chrono::duration_cast<std::chrono::milliseconds>(met_update_end - met_update_start);
+        std::cout << "  Ran met update in " << met_update_duration.count() << " ms" << std::endl;
+
+        auto regrid_start = std::chrono::high_resolution_clock::now();
+        #endif
         
         // Determine the altitude of each pressure edge after vertical advection and the 
         // application of new temperatures
@@ -184,6 +232,12 @@ SimStatus LAGRIDPlumeModel::runFullModel() {
         std::cout << "Remapping... " << std::endl;
         remapAllVars(timestepVars_.TRANSPORT_DT, mask, maskInfo);
 
+        #ifdef ENABLE_TIMING
+        auto regrid_end = std::chrono::high_resolution_clock::now();
+        auto regrid_duration = std::chrono::duration_cast<std::chrono::milliseconds>(regrid_end - regrid_start);
+        std::cout << "  Ran remapping in " << regrid_duration.count() << " ms" << std::endl;
+        #endif
+
         Vector_2D areas = VectorUtils::cellAreas(xEdges_, yEdges_);
         double numparts = iceAerosol_.TotalNumber_sum(areas);
         std::cout << "Num Particles: " << numparts << std::endl;
@@ -196,8 +250,22 @@ SimStatus LAGRIDPlumeModel::runFullModel() {
         // Advance time
         timestepVars_.curr_Time_s += timestepVars_.dt;
         timestepVars_.nTime++;
-        // Save data to file if it is time to do so
+
+        #ifdef ENABLE_TIMING
+        auto save_start = std::chrono::high_resolution_clock::now();
+        #endif
+
         saveTSAerosol();
+
+        #ifdef ENABLE_TIMING
+        auto save_end = std::chrono::high_resolution_clock::now();
+        auto save_duration = std::chrono::duration_cast<std::chrono::milliseconds>(save_end - save_start);
+        std::cout << "  Ran save in " << save_duration.count() << " ms" << std::endl;
+
+        auto timestep_end = std::chrono::high_resolution_clock::now();
+        auto timestep_duration = std::chrono::duration_cast<std::chrono::milliseconds>(timestep_end - timestep_start);
+        std::cout << "Ran timestep in " << timestep_duration.count() << " ms" << std::endl;
+        #endif
 
         if(EARLY_STOP) {
             status = SimStatus::Complete;
@@ -368,6 +436,10 @@ void LAGRIDPlumeModel::updateDiffVecs() {
     }
 }
 void LAGRIDPlumeModel::runTransport(double timestep) {
+
+    #ifdef ENABLE_TIMING
+    auto start = std::chrono::high_resolution_clock::now();
+    #endif
     //Update the zero bc to reflect grid size changes
     auto ZERO_BC = FVM_ANDS::bcFrom2DVector(iceAerosol_.getPDF()[0], true);
 
@@ -381,7 +453,25 @@ void LAGRIDPlumeModel::runTransport(double timestep) {
 
     const FVM_ANDS::AdvDiffParams fvmSolverInitParams(0, 0, shear_rep_, input_.horizDiff(), input_.vertiDiff(), timestepVars_.TRANSPORT_DT);
     const FVM_ANDS::BoundaryConditions ZERO_BC_INIT = FVM_ANDS::bcFrom2DVector(iceAerosol_.getPDF()[0], true);
+
+    #ifdef ENABLE_TIMING
+    auto end = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+    std::cout << "      Initialized transport in " << duration.count() << " ms" << std::endl;
+
+    start = std::chrono::high_resolution_clock::now();
+    #endif
+
     updateDiffVecs();
+
+    #ifdef ENABLE_TIMING
+    end = std::chrono::high_resolution_clock::now();
+    duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+    std::cout << "      Updated DiffVecs in " << duration.count() << " ms" << std::endl;
+
+    start = std::chrono::high_resolution_clock::now();
+    #endif
+
     //Transport the Ice Aerosol PDF
     #pragma omp parallel for default(shared)
     for ( UInt n = 0; n < iceAerosol_.getNBin(); n++ ) {
@@ -397,6 +487,14 @@ void LAGRIDPlumeModel::runTransport(double timestep) {
         //passing in "false" to the "parallelAdvection" param to not spawn more threads
         solver.operatorSplitSolve2DVec(iceAerosol_.getPDF()[n], ZERO_BC, false);
     }
+
+    #ifdef ENABLE_TIMING
+    end = std::chrono::high_resolution_clock::now();
+    duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+    std::cout << "      Ran ice aerosol transport in " << duration.count() << " ms" << std::endl;
+
+    start = std::chrono::high_resolution_clock::now();
+    #endif
 
     //Transport H2O
     {   
@@ -426,6 +524,14 @@ void LAGRIDPlumeModel::runTransport(double timestep) {
         }
     }
 
+    #ifdef ENABLE_TIMING
+    end = std::chrono::high_resolution_clock::now();
+    duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+    std::cout << "      Ran H2O transport in " << duration.count() << " ms" << std::endl;
+
+    start = std::chrono::high_resolution_clock::now();
+    #endif
+
     //Transport the contrail tracer
     {   
         //Identical settings to H2O
@@ -436,6 +542,12 @@ void LAGRIDPlumeModel::runTransport(double timestep) {
 
         solver.operatorSplitSolve2DVec(Contrail_, ZERO_BC);
     }
+
+    #ifdef ENABLE_TIMING
+    end = std::chrono::high_resolution_clock::now();
+    duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+    std::cout << "      Ran contrail tracer transport in " << duration.count() << " ms" << std::endl;
+    #endif
 }
 
 std::pair<LAGRID::twoDGridVariable,LAGRID::twoDGridVariable> LAGRIDPlumeModel::remapVariable(const VectorUtils::MaskInfo& maskInfo, const BufferInfo& buffers, const Vector_2D& phi, const std::vector<std::vector<int>>& mask) {

--- a/Code.v05-00/src/Core/LAGRIDPlumeModel.cpp
+++ b/Code.v05-00/src/Core/LAGRIDPlumeModel.cpp
@@ -1,6 +1,7 @@
 #include <chrono>
 #include <filesystem>
 #include <memory>
+#include <ratio>
 #include "AIM/Settling.hpp"
 #include "Util/PlumeModelUtils.hpp"
 #include "Core/Status.hpp"
@@ -478,6 +479,17 @@ void LAGRIDPlumeModel::runTransport(double timestep) {
     Eigen::VectorXd diffCoeffX_eigen = FVM_ANDS::std2dVec_to_eigenVec(diffCoeffX_);
     Eigen::VectorXd diffCoeffY_eigen = FVM_ANDS::std2dVec_to_eigenVec(diffCoeffY_);
 
+    #ifdef ENABLE_TIMING
+    end = std::chrono::high_resolution_clock::now();
+    auto duration_us = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+    std::cout << "      Copies vec2Eigen in " << duration_us.count() << " us" << std::endl;
+
+    start = std::chrono::high_resolution_clock::now();
+    #endif
+
+
+    /* PRECOMPUTE THE COEFFICIENT MATRIX FOR ALL AEROSOL BINS */
+
     // Cache the coefficients matrix because it is expensive to build and is identical
     // across all aerosol bins.
     // This is only true for operator splitting because the matrix is only used
@@ -485,32 +497,80 @@ void LAGRIDPlumeModel::runTransport(double timestep) {
     bool useOperatorSplit = true;
     // Need to instantiate a solver instance to compute the matrix, this solver is not used otherwise
     FVM_ANDS::FVM_Solver template_solver(fvmSolverInitParams, xCoords_, yCoords_, ZERO_BC_INIT, H2O_eigen);
+    std::shared_ptr<const Eigen::SparseMatrix<double, Eigen::RowMajor>> prebuilt_matrix;
     if (useOperatorSplit) {
         template_solver.updateTimestep(timestep);
         template_solver.updateDiffusion(diffCoeffX_eigen, diffCoeffY_eigen);
+
+        #ifdef ENABLE_TIMING
+        end = std::chrono::high_resolution_clock::now();
+        duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+        std::cout << "      Template solver instantiation " << duration.count() << " ms" << std::endl;
+
+        start = std::chrono::high_resolution_clock::now();
+        #endif
+
         template_solver.buildCoeffMatrix(useOperatorSplit);
+
+        #ifdef ENABLE_TIMING
+        end = std::chrono::high_resolution_clock::now();
+        duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+        std::cout << "      Template build matrix creation " << duration.count() << " ms" << std::endl;
+
+        start = std::chrono::high_resolution_clock::now();
+        #endif
+
+        prebuilt_matrix = template_solver.coefMatrixPtr();
     }
 
     //Transport the Ice Aerosol PDF
-    #pragma omp parallel for default(shared)
+
+    /* PRE-ALLOCATE A SOLVER POOL */
+
+    // Pre-allocate one solver per thread to creating a new solver each iteration
+    // Each thread will reuse its solver for all its assigned bins.
+    // Use vector<unique_ptr<solver>> and not directly a vector<solver> because of unique_pointers
+    // in the solver object which cannot be moved...
+    // This forces the instantiation of the solvers to be serial which is a slowdown
+    // relative to the naive each iteration creates a new solver...
+    // This slowdown is mostly compensated for by the gains of caching the matrix:
+    // For 8 cpus there is a slight slowdown between naive and preallocating solvers:
+    // -> preallocating solvers + caching the matrix (this)
+    // -> Naive each iteration of the aerosol bins loop creates its own solver (previous)
+    // For 1 cpu however we get a 15-35% speedup on transport (which gets better as the grid is larger
+    // e.g. the older the contrail the better the speedup for each transport step)
+    std::vector<std::unique_ptr<FVM_ANDS::FVM_Solver>> solver_pool;
+    solver_pool.reserve(numThreads_);
+    
+    for (int i = 0; i < numThreads_; ++i) {
+        solver_pool.emplace_back(std::make_unique<FVM_ANDS::FVM_Solver>(
+            fvmSolverInitParams, xCoords_, yCoords_, ZERO_BC_INIT, H2O_eigen));
+        solver_pool.back()->updateTimestep(timestep);
+        solver_pool.back()->updateDiffusion(diffCoeffX_eigen, diffCoeffY_eigen);
+        if (useOperatorSplit) {
+            solver_pool.back()->setPrebuiltMatrix(prebuilt_matrix);
+        }
+    }
+
+    #ifdef ENABLE_TIMING
+    end = std::chrono::high_resolution_clock::now();
+    duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+    std::cout << "      Init solver pool " << duration.count() << " ms" << std::endl;
+
+    start = std::chrono::high_resolution_clock::now();
+    #endif
+    
+    #pragma omp parallel for default(shared) schedule(dynamic)
     for ( UInt n = 0; n < iceAerosol_.getNBin(); n++ ) {
         /* Transport particle number and volume for each bin and
             * recompute centers of each bin for each grid cell
             * accordingly */
-        // Ideally we would create 1 solver and use it for all bins, but solver.updateAdvection()
-        // mutates the solver which would not work with this parallel loop. This is why
-        // we create 1 solver per iteration, and why caching the coefficient matrix is useful
-        // Refactoring the solver to enable 1 solver for all would save some data copies
-        FVM_ANDS::FVM_Solver solver(fvmSolverInitParams, xCoords_, yCoords_, ZERO_BC_INIT, H2O_eigen);
-        //Update solver params
-        solver.updateTimestep(timestep);
-        solver.updateDiffusion(diffCoeffX_eigen, diffCoeffY_eigen);
+        
+        int tid = omp_get_thread_num();
+        auto& solver = *solver_pool[tid];
+        
+        //Update solver params for this bin
         solver.updateAdvection(0, -vFall_[n], shear_rep_);
-
-        // Set the weights which we already computed, saves ~0-10 ms per bin depending on grid size
-        if (useOperatorSplit){
-            solver.setPrebuiltMatrix(template_solver.coefMatrix());
-        }
 
         //passing in "false" to the "parallelAdvection" param to not spawn more threads
         solver.operatorSplitSolve2DVec(iceAerosol_.getPDF()[n], ZERO_BC, false);

--- a/Code.v05-00/src/Core/LAGRIDPlumeModel.cpp
+++ b/Code.v05-00/src/Core/LAGRIDPlumeModel.cpp
@@ -500,7 +500,18 @@ void LAGRIDPlumeModel::runTransport(double timestep) {
     std::shared_ptr<const Eigen::SparseMatrix<double, Eigen::RowMajor>> prebuilt_matrix;
     if (useOperatorSplit) {
         template_solver.updateTimestep(timestep);
+
+        #ifdef ENABLE_TIMING
+        auto start_diff = std::chrono::high_resolution_clock::now();
+        #endif
+
         template_solver.updateDiffusion(diffCoeffX_eigen, diffCoeffY_eigen);
+
+        #ifdef ENABLE_TIMING
+        auto end_diff = std::chrono::high_resolution_clock::now();
+        duration_us = std::chrono::duration_cast<std::chrono::microseconds>(end_diff - start_diff);
+        std::cout << "      updateDiffusion " << duration_us.count() << " us" << std::endl;
+        #endif
 
         #ifdef ENABLE_TIMING
         end = std::chrono::high_resolution_clock::now();

--- a/Code.v05-00/src/Core/LAGRIDPlumeModel.cpp
+++ b/Code.v05-00/src/Core/LAGRIDPlumeModel.cpp
@@ -1,7 +1,6 @@
 #include <chrono>
 #include <filesystem>
 #include <memory>
-#include <ratio>
 #include "AIM/Settling.hpp"
 #include "Util/PlumeModelUtils.hpp"
 #include "Core/Status.hpp"
@@ -497,7 +496,7 @@ void LAGRIDPlumeModel::runTransport(double timestep) {
     bool useOperatorSplit = true;
     // Need to instantiate a solver instance to compute the matrix, this solver is not used otherwise
     FVM_ANDS::FVM_Solver template_solver(fvmSolverInitParams, xCoords_, yCoords_, ZERO_BC_INIT, H2O_eigen);
-    std::shared_ptr<const Eigen::SparseMatrix<double, Eigen::RowMajor>> prebuilt_matrix;
+    std::shared_ptr<const Eigen::SparseMatrix<double, Eigen::RowMajor>> shared_totalCoefMatrixPtr;
     if (useOperatorSplit) {
         template_solver.updateTimestep(timestep);
 
@@ -531,7 +530,7 @@ void LAGRIDPlumeModel::runTransport(double timestep) {
         start = std::chrono::high_resolution_clock::now();
         #endif
 
-        prebuilt_matrix = template_solver.coefMatrixPtr();
+        shared_totalCoefMatrixPtr = template_solver.coefMatrixPtr();
     }
 
     //Transport the Ice Aerosol PDF
@@ -559,7 +558,7 @@ void LAGRIDPlumeModel::runTransport(double timestep) {
         solver_pool.back()->updateTimestep(timestep);
         solver_pool.back()->updateDiffusion(diffCoeffX_eigen, diffCoeffY_eigen);
         if (useOperatorSplit) {
-            solver_pool.back()->setPrebuiltMatrix(prebuilt_matrix);
+            solver_pool.back()->setPrebuiltMatrix(shared_totalCoefMatrixPtr);
         }
     }
 
@@ -577,6 +576,7 @@ void LAGRIDPlumeModel::runTransport(double timestep) {
             * recompute centers of each bin for each grid cell
             * accordingly */
         
+        // Fetch the solver for this thread
         int tid = omp_get_thread_num();
         auto& solver = *solver_pool[tid];
         

--- a/Code.v05-00/src/Core/LAGRIDPlumeModel.cpp
+++ b/Code.v05-00/src/Core/LAGRIDPlumeModel.cpp
@@ -478,17 +478,39 @@ void LAGRIDPlumeModel::runTransport(double timestep) {
     Eigen::VectorXd diffCoeffX_eigen = FVM_ANDS::std2dVec_to_eigenVec(diffCoeffX_);
     Eigen::VectorXd diffCoeffY_eigen = FVM_ANDS::std2dVec_to_eigenVec(diffCoeffY_);
 
+    // Cache the coefficients matrix because it is expensive to build and is identical
+    // across all aerosol bins.
+    // This is only true for operator splitting because the matrix is only used
+    // for diffusion. The boolean here is to make this explicit, it gets compiled away.
+    bool useOperatorSplit = true;
+    // Need to instantiate a solver instance to compute the matrix, this solver is not used otherwise
+    FVM_ANDS::FVM_Solver template_solver(fvmSolverInitParams, xCoords_, yCoords_, ZERO_BC_INIT, H2O_eigen);
+    if (useOperatorSplit) {
+        template_solver.updateTimestep(timestep);
+        template_solver.updateDiffusion(diffCoeffX_eigen, diffCoeffY_eigen);
+        template_solver.buildCoeffMatrix(useOperatorSplit);
+    }
+
     //Transport the Ice Aerosol PDF
     #pragma omp parallel for default(shared)
     for ( UInt n = 0; n < iceAerosol_.getNBin(); n++ ) {
         /* Transport particle number and volume for each bin and
             * recompute centers of each bin for each grid cell
             * accordingly */
+        // Ideally we would create 1 solver and use it for all bins, but solver.updateAdvection()
+        // mutates the solver which would not work with this parallel loop. This is why
+        // we create 1 solver per iteration, and why caching the coefficient matrix is useful
+        // Refactoring the solver to enable 1 solver for all would save some data copies
         FVM_ANDS::FVM_Solver solver(fvmSolverInitParams, xCoords_, yCoords_, ZERO_BC_INIT, H2O_eigen);
         //Update solver params
         solver.updateTimestep(timestep);
         solver.updateDiffusion(diffCoeffX_eigen, diffCoeffY_eigen);
         solver.updateAdvection(0, -vFall_[n], shear_rep_);
+
+        // Set the weights which we already computed, saves ~0-10 ms per bin depending on grid size
+        if (useOperatorSplit){
+            solver.setPrebuiltMatrix(template_solver.coefMatrix());
+        }
 
         //passing in "false" to the "parallelAdvection" param to not spawn more threads
         solver.operatorSplitSolve2DVec(iceAerosol_.getPDF()[n], ZERO_BC, false);

--- a/Code.v05-00/src/FVM_ANDS/AdvDiffSystem.cpp
+++ b/Code.v05-00/src/FVM_ANDS/AdvDiffSystem.cpp
@@ -1,6 +1,8 @@
 #include <FVM_ANDS/AdvDiffSystem.hpp>
 #include <chrono>
 #include <math.h>
+#include <iostream>
+#include "APCEMM.h"
 
 namespace FVM_ANDS{
     AdvDiffSystem::AdvDiffSystem(const AdvDiffParams& params, const Vector_1D xCoords, const Vector_1D yCoords, const BoundaryConditions& bc, const Eigen::VectorXd& phi_init, vecFormat format) :
@@ -44,10 +46,41 @@ namespace FVM_ANDS{
         std::generate_n(std::back_inserter(points_), nTotalPoints_, [] { return std::make_unique<Point>(); });
         totalCoefMatrix_.resize(nTotalPoints_, nTotalPoints_);
 
+        #ifdef ENABLE_TIMING
+        auto start = std::chrono::high_resolution_clock::now();
+        #endif
         updateDiffusion(params.Dh, params.Dv);
+        #ifdef ENABLE_TIMING
+        auto end = std::chrono::high_resolution_clock::now();
+        auto duration_us = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+        std::cout << "          AdvDiffSys Construtor: updateDiff " << duration_us.count() << " us" << std::endl;
+
+        start = std::chrono::high_resolution_clock::now();
+        #endif
         initVelocVecs();
+        #ifdef ENABLE_TIMING
+        end = std::chrono::high_resolution_clock::now();
+        duration_us = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+        std::cout << "          AdvDiffSys Construtor: initVelocVecs " << duration_us.count() << " us" << std::endl;
+
+        start = std::chrono::high_resolution_clock::now();
+        #endif
         buildPointList();
+        #ifdef ENABLE_TIMING
+        end = std::chrono::high_resolution_clock::now();
+        duration_us = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+        std::cout << "          AdvDiffSys Construtor: buildPointList " << duration_us.count() << " us" << std::endl;
+
+        start = std::chrono::high_resolution_clock::now();
+        #endif
         applyBoundaryCondition();
+        #ifdef ENABLE_TIMING
+        end = std::chrono::high_resolution_clock::now();
+        duration_us = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+        std::cout << "          AdvDiffSys Construtor: applyBoundaryCondition " << duration_us.count() << " us" << std::endl;
+
+        start = std::chrono::high_resolution_clock::now();
+        #endif
     }
 
     void AdvDiffSystem::initVelocVecs(){

--- a/Code.v05-00/src/FVM_ANDS/AdvDiffSystem.cpp
+++ b/Code.v05-00/src/FVM_ANDS/AdvDiffSystem.cpp
@@ -189,7 +189,7 @@ namespace FVM_ANDS{
     }
     void AdvDiffSystem::buildCoeffMatrix(bool operatorSplit){
         // Skip if we have a prebuilt matrix
-        if (use_prebuilt_matrix_) {
+        if (use_shared_totalCoefMatrix_) {
             return;
         }
         

--- a/Code.v05-00/src/FVM_ANDS/AdvDiffSystem.cpp
+++ b/Code.v05-00/src/FVM_ANDS/AdvDiffSystem.cpp
@@ -155,6 +155,11 @@ namespace FVM_ANDS{
         }
     }
     void AdvDiffSystem::buildCoeffMatrix(bool operatorSplit){
+        // Skip if we have a prebuilt matrix
+        if (use_prebuilt_matrix_) {
+            return;
+        }
+        
         //Crank-Nicholson Discretization. Builds the Advection terms of the A matrix 
         //in the system A * phi_t+1 = b.
 

--- a/Code.v05-00/src/FVM_ANDS/FVM_Solver.cpp
+++ b/Code.v05-00/src/FVM_ANDS/FVM_Solver.cpp
@@ -102,7 +102,7 @@ namespace FVM_ANDS{
         // Should never happen given using operatorSplit is hard coded into runTransport and above, but serves as
         // a guardrail for future code changes
         if (!operatorSplit && matrix_prebuilt_){
-            throw std::runtime_error("When not using operatorSlit, the matrix coefficients cannot be reused");
+            throw std::runtime_error("When not using operatorSplitSolve, the matrix coefficients cannot be reused");
         }
 
         // If the matrix has not already been set, compute it

--- a/Code.v05-00/src/FVM_ANDS/FVM_Solver.cpp
+++ b/Code.v05-00/src/FVM_ANDS/FVM_Solver.cpp
@@ -1,5 +1,6 @@
 #include <chrono>
 #include <iostream>
+#include <stdexcept>
 #include "APCEMM.h"
 #include "FVM_ANDS/FVM_Solver.hpp"
 namespace FVM_ANDS{
@@ -97,7 +98,17 @@ namespace FVM_ANDS{
 
         //Step 3: Implicitly solve diffusion (first to help smoothen out potential steep gradients)
         advDiffSys_.updateTimestep(dt_max);
-        advDiffSys_.buildCoeffMatrix(operatorSplit);
+
+        // Should never happen given using operatorSplit is hard coded into runTransport and above, but serves as
+        // a guardrail for future code changes
+        if (!operatorSplit && matrix_prebuilt_){
+            throw std::runtime_error("When not using operatorSlit, the matrix coefficients cannot be reused");
+        }
+
+        // If the matrix has not already been set, compute it
+        if (!matrix_prebuilt_){
+            advDiffSys_.buildCoeffMatrix(operatorSplit);
+        }
 
         #ifdef ENABLE_TIMING
         stop = std::chrono::high_resolution_clock::now();

--- a/Code.v05-00/src/FVM_ANDS/FVM_Solver.cpp
+++ b/Code.v05-00/src/FVM_ANDS/FVM_Solver.cpp
@@ -1,3 +1,6 @@
+#include <chrono>
+#include <iostream>
+#include "APCEMM.h"
 #include "FVM_ANDS/FVM_Solver.hpp"
 namespace FVM_ANDS{
     FVM_Solver::FVM_Solver(const AdvDiffParams& params, const Vector_1D xCoords, const Vector_1D yCoords, const BoundaryConditions& bc, const Eigen::VectorXd& phi_init, bool useDiagPreCond, int maxIters, double convergenceThres)
@@ -56,6 +59,11 @@ namespace FVM_ANDS{
     }
 
     const Eigen::VectorXd& FVM_Solver::operatorSplitSolve(bool parallelAdvection, double courant_max) {
+
+        #ifdef ENABLE_TIMING
+        auto opsplit_start = std::chrono::high_resolution_clock::now();
+        #endif
+
         //Strang Splitting
         //Step 1: Calculate explicit advection timestep based on CFL condition set
 
@@ -67,7 +75,10 @@ namespace FVM_ANDS{
         int n_timesteps_advection_half =  std::ceil((0.5 * dt_max) / dt_adv);
         dt_adv = (0.5 * dt_max) / n_timesteps_advection_half;
 
-        // auto start = std::chrono::high_resolution_clock::now();
+        #ifdef ENABLE_TIMING
+        std::cout << "              N Advection timesteps = 2 * " << n_timesteps_advection_half << std::endl;
+        auto start = std::chrono::high_resolution_clock::now();
+        #endif
 
         //Step 2: Solve Advection for half timestep
         advDiffSys_.updateTimestep(dt_adv);
@@ -76,17 +87,35 @@ namespace FVM_ANDS{
             advDiffSys_.applyBoundaryCondition();
         }
 
-        // auto stop = std::chrono::high_resolution_clock::now();
-        // auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(stop-start);
-        // std::cout << "First Halfstep Advection Solve Time: " << duration.count() << std::endl;
+        #ifdef ENABLE_TIMING
+        auto stop = std::chrono::high_resolution_clock::now();
+        auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(stop-start);
+        std::cout << "              First Halfstep Advection Solve Time: " << duration.count() << " ms" << std::endl;
 
-        // start = std::chrono::high_resolution_clock::now();
+        start = std::chrono::high_resolution_clock::now();
+        #endif
 
         //Step 3: Implicitly solve diffusion (first to help smoothen out potential steep gradients)
         advDiffSys_.updateTimestep(dt_max);
-        //Build matrix takes ~40ms atm
         advDiffSys_.buildCoeffMatrix(operatorSplit);
+
+        #ifdef ENABLE_TIMING
+        stop = std::chrono::high_resolution_clock::now();
+        duration = std::chrono::duration_cast<std::chrono::milliseconds>(stop-start);
+        std::cout << "              Build diffusion matrix Time: " << duration.count() << " ms" << std::endl;
+
+        start = std::chrono::high_resolution_clock::now();
+        #endif
+
         advDiffSys_.calcRHS();
+
+        #ifdef ENABLE_TIMING
+        stop = std::chrono::high_resolution_clock::now();
+        duration = std::chrono::duration_cast<std::chrono::milliseconds>(stop-start);
+        std::cout << "              Calc RHS matrix Time: " << duration.count() << " ms" << std::endl;
+
+        start = std::chrono::high_resolution_clock::now();
+        #endif
 
         // auto mat = advDiffSys_.getCoefMatrix();
         // auto b = advDiffSys_.getRHS();
@@ -96,13 +125,16 @@ namespace FVM_ANDS{
         
         advDiffSys_.sor_solve();
 
-        // stop = std::chrono::high_resolution_clock::now();
-        // duration = std::chrono::duration_cast<std::chrono::milliseconds>(stop-start);
-        // std::cout << "Diffusion Solve Time: " << duration.count() << std::endl;
+        #ifdef ENABLE_TIMING
+        stop = std::chrono::high_resolution_clock::now();
+        duration = std::chrono::duration_cast<std::chrono::milliseconds>(stop-start);
+        std::cout << "              Diffusion SOR Solve Time: " << duration.count() << " ms" << std::endl;
+
+        start = std::chrono::high_resolution_clock::now();
+        #endif
 
         //Step 4: Explicitly solve advection to full timestep
 
-        // start = std::chrono::high_resolution_clock::now();
         advDiffSys_.updateTimestep(dt_adv);
         for(int i = 0; i < n_timesteps_advection_half; i++){
             advDiffSys_.updatePhi(advDiffSys_.forwardEulerAdvection(operatorSplit));
@@ -111,9 +143,14 @@ namespace FVM_ANDS{
 
         advDiffSys_.updateTimestep(dt_max);
 
-        // stop = std::chrono::high_resolution_clock::now();
-        // duration = std::chrono::duration_cast<std::chrono::milliseconds>(stop-start);
-        // std::cout << "Advection second step Solve Time: " << duration.count() << std::endl;
+        #ifdef ENABLE_TIMING
+        stop = std::chrono::high_resolution_clock::now();
+        duration = std::chrono::duration_cast<std::chrono::milliseconds>(stop-start);
+        std::cout << "              Advection second step Solve Time: " << duration.count() << " ms" << std::endl;
+
+        duration = std::chrono::duration_cast<std::chrono::milliseconds>(stop-opsplit_start);
+        std::cout << "          Ran operatorSplitSolve in " << duration.count() << " ms" << std::endl;
+        #endif
 
         return advDiffSys_.phi();
     }

--- a/Code.v05-00/src/FVM_ANDS/FVM_Solver.cpp
+++ b/Code.v05-00/src/FVM_ANDS/FVM_Solver.cpp
@@ -3,7 +3,7 @@
 #include "APCEMM.h"
 #include "FVM_ANDS/FVM_Solver.hpp"
 namespace FVM_ANDS{
-    FVM_Solver::FVM_Solver(const AdvDiffParams& params, const Vector_1D xCoords, const Vector_1D yCoords, const BoundaryConditions& bc, const Eigen::VectorXd& phi_init, bool useDiagPreCond, int maxIters, double convergenceThres)
+    FVM_Solver::FVM_Solver(const AdvDiffParams& params, const Vector_1D& xCoords, const Vector_1D& yCoords, const BoundaryConditions& bc, const Eigen::VectorXd& phi_init, bool useDiagPreCond, int maxIters, double convergenceThres)
     :   maxIters_(maxIters),
         convergenceThres_(convergenceThres),
         advDiffSys_(AdvDiffSystem(params, xCoords, yCoords, bc, phi_init)),

--- a/Code.v05-00/src/YamlInputReader/YamlInputReader.cpp
+++ b/Code.v05-00/src/YamlInputReader/YamlInputReader.cpp
@@ -112,6 +112,10 @@ namespace YamlInputReader{
             input.SIMULATION_OMP_NUM_THREADS = 1;
         #endif
 
+        if (input.SIMULATION_OMP_NUM_THREADS > 4){
+            std::cout << ">>> Hint: APCEMM performance does not scale past 4 threads... ('OpenMP Num Threads' is set to " << input.SIMULATION_OMP_NUM_THREADS << ") <<<" << std::endl;
+        }
+
         YAML::Node paramSweepSubmenu = simNode["PARAM SWEEP SUBMENU"];
         input.SIMULATION_PARAMETER_SWEEP = parseBoolString(paramSweepSubmenu["Parameter sweep (T/F)"].as<string>(), "Parameter sweep (T/F)");
         input.SIMULATION_MONTECARLO = parseBoolString(paramSweepSubmenu["Run Monte Carlo (T/F)"].as<string>(), "Run Monte Carlo (T/F)");


### PR DESCRIPTION
# Summary
Addresses #89. PR makes the transport step faster in APCEMM. Improvements on total runtime are of order of 25% for single threads and 40% for 8 threads.

Tested correctness on randomly perturbed fields (scaled + gaussian perturbation) from the `issl_rhi140/` example for 4 hours. The results are bitwise identical for a single thread run. I could not test this for multi-threaded setups due to #19.

User facing changes:
- New compile option `-DENABLE_TIMING` to report profiling information around key parts of APCEMM
- Warning if OMP Num threads > 4 (see below, might remove this...)

# Code changes
There are many things which could still be improved but would require a larger refactoring. This is a first step at improving the transport step. Most of the changes are focused around making the ice aerosol transport step faster.

- `FVM_Solver::FVM_Solver` constructor gets coords data by reference instead of value
- Reduced the number of conversions from `Vector_2D` to `Eigen::VectorXd`
- Cached the diffusion matrix used in `operatorSplitSolve` across all 38 aerosol size bins instead of recomputing it every time
- Generate a `FVM_Solver::FVM_Solver` pool such that threads do not create a new solver each iteration

The last two points are the ones which make the largest difference by far.

# Benchmark
Benchmark is run on the `examples/issl_rhi140/` data for 4h. Overall APCEMM scales badly with number of CPUs > 2. In `main` I think this is because of a lot of repeated work. In this PR, this is likely due to expensive copies when initializing the solver pool.

Speedup varies as a function of number of CPUs and is heavily dependent on machine. I ran this both on a fully reserved node (`c041` on Hex) as well as locally, and got very different speedups, ranging from x1.25 to x2. I suspect this is cache  size related.

Your mileage may vary, but across all tests on different nodes this resulted in a net speedup apart from a case using 8 CPUs. There I sometimes found slight performance regressions (0.95-1x performance) compared to 8 CPUs on main, which I why I added a warning to test this yourself. However with the speedup from this PR, it might be worth starting in parallel two separate APCEMM simulations with 4 CPUs each rather than sequentially doing one after the other with 8 CPUs.

<img width="2434" height="1234" alt="image" src="https://github.com/user-attachments/assets/a0d3450e-54eb-4808-b828-1300b5ffde16" />

<img width="2434" height="1234" alt="image" src="https://github.com/user-attachments/assets/bd291ea2-5b4d-470a-9917-ba05fc4d91f9" />


Time spent overall in each part of APCEMM still shows that transport dominates, but it might be worth looking into the ice growth mechanisms too.
<img width="3034" height="1534" alt="image" src="https://github.com/user-attachments/assets/d85e37ac-8556-47d2-8d72-c5374d7c94c3" />


# Future improvements
I see two large avenues for further improvements, but they would require larger refactors:

1. Change the representation of most compute intensive variables to `Eigen::VectorXd` under the hood, with some light wrapper around it to allow for 2D or 3D indexing. This would avoid the (many) back and forth conversions throughout the code, and working with contiguous memory blocks will likely boost cache locality. It would also help with the saving of the 3D PSD distribution by eliminating the need for copying the data back to a contiguous format.

2. Refactor the solvers to be lighter and copiable/movable: eliminate the unique pointers for the `Points`, get rid of the Eigen solvers that we do not use, and separate the solver instances into a shared immutable state (diffusion vectors, diffusion matrix coefficients...) and a mutable state.  All of this would make the solvers must faster to initialize (fewer redundant computations, fewer copies) with would make the solver pool scale much better, and potentially bring performance improvements at 8 threads.


Let me know what you think.